### PR TITLE
Fixes #244: Separeted mutable from read-only game object arrays since…

### DIFF
--- a/TemplePlus/gamesystems/objects/gameobject.cpp
+++ b/TemplePlus/gamesystems/objects/gameobject.cpp
@@ -181,45 +181,45 @@ void GameObjectBody::SetString(obj_f field, const char * text)
 	*storageLoc = _strdup(text);
 }
 
-const GameInt32Array GameObjectBody::GetInt32Array(obj_f field) const
+GameInt32ReadOnlyArray GameObjectBody::GetInt32Array(obj_f field) const
 {
 	Expects(objectFields.GetType(field) == ObjectFieldType::Int32Array
 		|| objectFields.GetType(field) == ObjectFieldType::AbilityArray);
 
 	auto storageLoc = GetStorageLocation<ArrayHeader*>(field);
-	return GameInt32Array(const_cast<ArrayHeader**>(storageLoc));
+	return GameInt32ReadOnlyArray(const_cast<ArrayHeader**>(storageLoc));
 }
 
-const GameInt64Array GameObjectBody::GetInt64Array(obj_f field) const
+GameInt64ReadOnlyArray GameObjectBody::GetInt64Array(obj_f field) const
 {
 	Expects(objectFields.GetType(field) == ObjectFieldType::Int64Array);
 
 	auto storageLoc = GetStorageLocation<ArrayHeader*>(field);
-	return GameInt64Array(const_cast<ArrayHeader**>(storageLoc));
+	return GameInt64ReadOnlyArray(const_cast<ArrayHeader**>(storageLoc));
 }
 
-const GameObjectIdArray GameObjectBody::GetObjectIdArray(obj_f field) const
+GameObjectIdReadOnlyArray GameObjectBody::GetObjectIdArray(obj_f field) const
 {
 	Expects(objectFields.GetType(field) == ObjectFieldType::ObjArray);
 
 	auto storageLoc = GetStorageLocation<ArrayHeader*>(field);
-	return GameObjectIdArray(const_cast<ArrayHeader**>(storageLoc));
+	return GameObjectIdReadOnlyArray(const_cast<ArrayHeader**>(storageLoc));
 }
 
-const GameScriptArray GameObjectBody::GetScriptArray(obj_f field) const
+GameScriptReadOnlyArray GameObjectBody::GetScriptArray(obj_f field) const
 {
 	Expects(objectFields.GetType(field) == ObjectFieldType::ScriptArray);
 
 	auto storageLoc = GetStorageLocation<ArrayHeader*>(field);
-	return GameScriptArray(const_cast<ArrayHeader**>(storageLoc));
+	return GameScriptReadOnlyArray(const_cast<ArrayHeader**>(storageLoc));
 }
 
-const GameSpellArray GameObjectBody::GetSpellArray(obj_f field) const
+GameSpellReadOnlyArray GameObjectBody::GetSpellArray(obj_f field) const
 {
 	Expects(objectFields.GetType(field) == ObjectFieldType::SpellArray);
 
 	auto storageLoc = GetStorageLocation<ArrayHeader*>(field);
-	return GameSpellArray(const_cast<ArrayHeader**>(storageLoc));
+	return GameSpellReadOnlyArray(const_cast<ArrayHeader**>(storageLoc));
 }
 
 GameInt32Array GameObjectBody::GetMutableInt32Array(obj_f field)

--- a/TemplePlus/gamesystems/objects/gameobject.h
+++ b/TemplePlus/gamesystems/objects/gameobject.h
@@ -97,11 +97,11 @@ struct GameObjectBody {
 	const char *GetString(obj_f field) const;
 	void SetString(obj_f field, const char *text);
 
-	const GameInt32Array GetInt32Array(obj_f field) const;
-	const GameInt64Array GetInt64Array(obj_f field) const;
-	const GameObjectIdArray GetObjectIdArray(obj_f field) const;
-	const GameScriptArray GetScriptArray(obj_f field) const;
-	const GameSpellArray GetSpellArray(obj_f field) const;
+	GameInt32ReadOnlyArray GetInt32Array(obj_f field) const;
+	GameInt64ReadOnlyArray GetInt64Array(obj_f field) const;
+	GameObjectIdReadOnlyArray GetObjectIdArray(obj_f field) const;
+	GameScriptReadOnlyArray GetScriptArray(obj_f field) const;
+	GameSpellReadOnlyArray GetSpellArray(obj_f field) const;
 
 	// Convenience array accessors
 	int32_t GetInt32(obj_f field, size_t index) const;


### PR DESCRIPTION
… the read-only array got converted to a mutable one by copying by accident.