### PR TITLE
Fixed vector access for prereq reads

### DIFF
--- a/TemplePlus/feat.cpp
+++ b/TemplePlus/feat.cpp
@@ -217,7 +217,6 @@ void LegacyFeatSystem::_GetNewFeatsFromFile()
 		auto featFile = tio_fopen(fmt::format("rules\\feats\\{}",f.name).c_str(), "rt");
 
 		char lineContent[2000]={0,};
-		FeatPrereq featPrereq;
 		NewFeatSpec featSpec;
 		while (tio_fgets(lineContent, 1000, featFile)){
 			auto len = strlen(lineContent);
@@ -260,25 +259,15 @@ void LegacyFeatSystem::_GetNewFeatsFromFile()
 					
 					if (prereqArgCount < prereqCount)
 					{
-						if (featSpec.prereqs.capacity() <= prereqArgCount)
-						{
-							featPrereq.featPrereqCodeArg = atol(ch);
-							featSpec.prereqs.push_back(featPrereq);
-							prereqArgCount++;
-						}
-						else
-							featSpec.prereqs[prereqArgCount++].featPrereqCodeArg = atol(ch);
+						if (featSpec.prereqs.size() <= prereqArgCount)
+							featSpec.prereqs.resize(featSpec.prereqs.size() + 1);
+						featSpec.prereqs[prereqArgCount++].featPrereqCodeArg = atol(ch);
 					}
 					else
 					{
-						if (featSpec.prereqs.capacity() <= prereqCount)
-						{
-							featPrereq.featPrereqCode = atol(ch);
-							featSpec.prereqs.push_back(featPrereq);
-							prereqCount++;
-						}
-						else
-							featSpec.prereqs[prereqCount++].featPrereqCode = atol(ch);
+						if (featSpec.prereqs.size() <= prereqCount)
+							featSpec.prereqs.resize(featSpec.prereqs.size() + 1);
+						featSpec.prereqs[prereqCount++].featPrereqCode = atol(ch);
 					}
 
 					// advance till next piece of content

--- a/TemplePlus/feat.cpp
+++ b/TemplePlus/feat.cpp
@@ -255,6 +255,9 @@ void LegacyFeatSystem::_GetNewFeatsFromFile()
 				auto prereqArgCount = 0;
 				for (auto ch = lineContent + 8; *ch != 0; ch++)
 				{
+					if ( *ch == ':' || *ch == ' ' || *ch == '\t')
+						continue;
+					
 					if (prereqArgCount < prereqCount)
 					{
 						if (featSpec.prereqs.capacity() <= prereqArgCount)

--- a/TemplePlus/feat.cpp
+++ b/TemplePlus/feat.cpp
@@ -217,6 +217,7 @@ void LegacyFeatSystem::_GetNewFeatsFromFile()
 		auto featFile = tio_fopen(fmt::format("rules\\feats\\{}",f.name).c_str(), "rt");
 
 		char lineContent[2000]={0,};
+		FeatPrereq featPrereq;
 		NewFeatSpec featSpec;
 		while (tio_fgets(lineContent, 1000, featFile)){
 			auto len = strlen(lineContent);
@@ -254,15 +255,28 @@ void LegacyFeatSystem::_GetNewFeatsFromFile()
 				auto prereqArgCount = 0;
 				for (auto ch = lineContent + 8; *ch != 0; ch++)
 				{
-					if ( *ch == ':' || *ch == ' ' || *ch == '\t')
-						continue;
-					
 					if (prereqArgCount < prereqCount)
 					{
-						featSpec.prereqs[prereqArgCount++].featPrereqCodeArg = atol(ch);
+						if (featSpec.prereqs.capacity() <= prereqArgCount)
+						{
+							featPrereq.featPrereqCodeArg = atol(ch);
+							featSpec.prereqs.push_back(featPrereq);
+							prereqArgCount++;
+						}
+						else
+							featSpec.prereqs[prereqArgCount++].featPrereqCodeArg = atol(ch);
 					}
 					else
-						featSpec.prereqs[prereqCount++].featPrereqCode = atol(ch);
+					{
+						if (featSpec.prereqs.capacity() <= prereqCount)
+						{
+							featPrereq.featPrereqCode = atol(ch);
+							featSpec.prereqs.push_back(featPrereq);
+							prereqCount++;
+						}
+						else
+							featSpec.prereqs[prereqCount++].featPrereqCode = atol(ch);
+					}
 
 					// advance till next piece of content
 					while (*ch && *ch !=  ' ' && *ch != '\t')

--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -351,6 +351,19 @@ int InventorySystem::ItemDrop(objHndl item)
 	return _ItemDrop(item);
 }
 
+int InventorySystem::ItemDrop(objHndl critter, EquipSlot slot) {
+	auto item = inventory.GetItemAtInvIdx(critter, InvIdxForSlot(slot));
+	if (!item)
+		return FALSE;
+
+	auto invenLoc = GetInventoryLocation(item);
+	if (!IsInvIdxWorn(invenLoc))
+		return TRUE;
+
+	ItemDrop(item);
+	return TRUE;
+}
+
 int InventorySystem::SetItemParent(objHndl item, objHndl receiver, ItemInsertFlags flags){
 
 	auto itemObj = gameSystems->GetObj().GetObject(item);

--- a/TemplePlus/inventory.h
+++ b/TemplePlus/inventory.h
@@ -116,6 +116,7 @@ struct InventorySystem : temple::AddressTable
 
 	void ForceRemove(objHndl item, objHndl parent);
 	int ItemDrop(objHndl item);
+	int ItemDrop(objHndl critter, Equipslot slot);
 	int ItemUnwield(objHndl item);
 	int ItemUnwieldByIdx(objHndl obj, int i);
 	int ItemUnwield(objHndl critter, EquipSlot slot);

--- a/TemplePlus/inventory.h
+++ b/TemplePlus/inventory.h
@@ -116,7 +116,7 @@ struct InventorySystem : temple::AddressTable
 
 	void ForceRemove(objHndl item, objHndl parent);
 	int ItemDrop(objHndl item);
-	int ItemDrop(objHndl critter, Equipslot slot);
+	int ItemDrop(objHndl critter, EquipSlot slot);
 	int ItemUnwield(objHndl item);
 	int ItemUnwieldByIdx(objHndl obj, int i);
 	int ItemUnwield(objHndl critter, EquipSlot slot);

--- a/TemplePlus/python/python_object.cpp
+++ b/TemplePlus/python/python_object.cpp
@@ -2434,7 +2434,8 @@ static PyObject* PyObjHandle_Unwield(PyObject* obj, PyObject* args) {
 	}
 
 	int es;
-	if (!PyArg_ParseTuple(args, "i:objhndl.item_worn_unwield",  &es)) {
+	objHndl item = objHndl::null;
+	if (!PyArg_ParseTuple(args, "i|O&:objhndl.item_worn_unwield",  &es, &ConvertObjHndl, &item)) {
 		return 0;
 	}
 
@@ -2442,6 +2443,11 @@ static PyObject* PyObjHandle_Unwield(PyObject* obj, PyObject* args) {
 	if (es >= EquipSlot::Count || es < 0)
 		es = EquipSlot::Invalid;
 	auto equipSlot = (EquipSlot)es;
+
+	if (item != objHndl::null && inventory.GetParent(item) == self->handle ) {
+		inventory.ItemDrop(item);
+		Py_RETURN_NONE;
+	}
 
 	inventory.ItemUnwield(self->handle,  equipSlot);
 	Py_RETURN_NONE;

--- a/TemplePlus/python/python_object.cpp
+++ b/TemplePlus/python/python_object.cpp
@@ -2434,8 +2434,8 @@ static PyObject* PyObjHandle_Unwield(PyObject* obj, PyObject* args) {
 	}
 
 	int es;
-	objHndl item = objHndl::null;
-	if (!PyArg_ParseTuple(args, "i|O&:objhndl.item_worn_unwield",  &es, &ConvertObjHndl, &item)) {
+	int flag = 0;
+	if (!PyArg_ParseTuple(args, "i|i:objhndl.item_worn_unwield",  &es, &flag)) {
 		return 0;
 	}
 
@@ -2444,8 +2444,8 @@ static PyObject* PyObjHandle_Unwield(PyObject* obj, PyObject* args) {
 		es = EquipSlot::Invalid;
 	auto equipSlot = (EquipSlot)es;
 
-	if (item != objHndl::null && inventory.GetParent(item) == self->handle ) {
-		inventory.ItemDrop(item);
+	if ( flag == 1 ) {
+		inventory.ItemDrop(self->handle, equipSlot);
 		Py_RETURN_NONE;
 	}
 


### PR DESCRIPTION
Tested before and after modification. Before, any feat with prereq values (or even attempting to write in there manually) crashed the code. After, game fully reaches main menu and plays without error.