### PR TITLE
Fix 3d particles not rotating properly

### DIFF
--- a/Infrastructure/include/infrastructure/meshes.h
+++ b/Infrastructure/include/infrastructure/meshes.h
@@ -392,6 +392,7 @@ namespace gfx {
 		float rotationYaw = 0;
 		AnimatedModelPtr parentAnim;
 		std::string attachedBoneName;
+		bool rotation3d = false; // Enables use of rotationRoll/rotationPitch/rotationYaw
 	};
 
 	class AnimatedModelFactory {

--- a/ParticleSystems/src/render_model.cpp
+++ b/ParticleSystems/src/render_model.cpp
@@ -33,6 +33,7 @@ namespace particles {
 		auto totalCount = emitter.GetActiveCount();
 
 		AnimatedModelParams animParams;
+		animParams.rotation3d = true;
 
 		// Lazily initialize render state
 		if (!emitter.HasRenderState()) {
@@ -67,6 +68,10 @@ namespace particles {
 		overrides.ignoreLighting = true;
 		overrides.overrideDiffuse = true;
 		
+		auto yaw = emitter.GetParamState(PartSysParamId::part_yaw);
+		auto pitch = emitter.GetParamState(PartSysParamId::part_pitch);
+		auto roll = emitter.GetParamState(PartSysParamId::part_roll);
+
 		while (it.HasNext()) {
 			auto particleIdx = it.Next();
 			auto age = emitter.GetParticleAge(particleIdx);
@@ -78,6 +83,16 @@ namespace particles {
 			animParams.offsetX = particleState.GetState(PSF_POS_VAR_X, particleIdx);
 			animParams.offsetY = particleState.GetState(PSF_POS_VAR_Z, particleIdx);
 			animParams.offsetZ = particleState.GetState(PSF_POS_VAR_Y, particleIdx);
+
+			if (yaw) {
+				animParams.rotationYaw = DirectX::XMConvertToRadians(yaw->GetValue(&emitter, particleIdx, age));
+			}
+			if (pitch) {
+				animParams.rotationPitch = DirectX::XMConvertToRadians(pitch->GetValue(&emitter, particleIdx, age));
+			}
+			if (roll) {
+				animParams.rotationRoll = DirectX::XMConvertToRadians(roll->GetValue(&emitter, particleIdx, age));
+			}
 
 			renderState.model->SetTime(animParams, age);
 

--- a/Temple/src/aasrenderer.cpp
+++ b/Temple/src/aasrenderer.cpp
@@ -216,7 +216,7 @@ void AasRenderer::Render(gfx::AnimatedModel *model,
 	auto materialIds(model->GetSubmeshes());
 	for (size_t i = 0; i < materialIds.size(); ++i) {
 		auto materialId = materialIds[i];
-		auto submesh(model->GetSubmesh(params, i));
+		auto submesh(params.rotation3d ? model->GetSubmeshForParticles(params, i) : model->GetSubmesh(params, i));
 		
 		// Remove special material marker in the upper byte and only 
 		// use the actual shader registration id


### PR DESCRIPTION
3d model particles were only rotation along a single axis because the wrong GetSubmesh function was used. This fixes this.