### PR TITLE
Moved the AAS renderer to the Infrastructure package

### DIFF
--- a/Infrastructure/Infrastructure.vcxproj
+++ b/Infrastructure/Infrastructure.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="breakpad\minidump_format.h" />
     <ClInclude Include="breakpad\scoped_ptr.h" />
     <ClInclude Include="breakpad\string_utils-inl.h" />
+    <ClInclude Include="include\aas\aas_renderer.h" />
     <ClInclude Include="include\fmt\container.h" />
     <ClInclude Include="include\fmt\format.h" />
     <ClInclude Include="include\fmt\ostream.h" />
@@ -259,6 +260,7 @@
     <ClCompile Include="include\fmt\ostream.cc" />
     <ClCompile Include="include\fmt\posix.cc" />
     <ClCompile Include="include\fmt\printf.cc" />
+    <ClCompile Include="src\aas\aas_renderer.cpp" />
     <ClCompile Include="src\allocator.cpp" />
     <ClCompile Include="breakpad.cpp" />
     <ClCompile Include="crypto.cpp" />

--- a/Infrastructure/Infrastructure.vcxproj.filters
+++ b/Infrastructure/Infrastructure.vcxproj.filters
@@ -321,6 +321,9 @@
     <ClInclude Include="include\fmt\string.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\aas\aas_renderer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="version.cpp">
@@ -450,6 +453,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="include\fmt\printf.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\aas\aas_renderer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Infrastructure/include/aas/aas_renderer.h
+++ b/Infrastructure/include/aas/aas_renderer.h
@@ -3,7 +3,6 @@
 
 #include <graphics/materials.h>
 #include <infrastructure/meshes.h>
-#include <temple/meshes.h>
 
 namespace gfx {
 	class RenderingDevice;
@@ -13,21 +12,21 @@ namespace gfx {
 	class ShapeRenderer3d;
 }
 
-namespace temple {
+namespace aas {
 
 	using AasStatePtr = std::unique_ptr<struct AasRenderData>;
 
 	struct AasRenderSubmeshData;
 
-	class AasRenderer : public gfx::AnimatedModelRenderer {
+	class Renderer : public gfx::AnimatedModelRenderer {
 	public:
-		AasRenderer(
-			AasAnimatedModelFactory &aasFactory,
+		Renderer(
+			gfx::AnimatedModelFactory &aasFactory,
 			gfx::RenderingDevice &device,
 			gfx::ShapeRenderer2d &shapeRenderer2d,
 			gfx::ShapeRenderer3d &shapeRenderer3d,
 			gfx::MdfMaterialFactory &mdfFactory);
-		~AasRenderer();
+		~Renderer();
 
 		void Render(gfx::AnimatedModel *model,
 			const gfx::AnimatedModelParams& params,
@@ -52,14 +51,12 @@ namespace temple {
 			bool softShadows);
 
 	private:
-		AasAnimatedModelFactory &mAasFactory;
+		gfx::AnimatedModelFactory &mAasFactory;
 		gfx::RenderingDevice &mDevice;
 		gfx::ShapeRenderer2d &mShapeRenderer2d;
 		gfx::ShapeRenderer3d &mShapeRenderer3d;
 		gfx::Material mGeometryShadowMaterial;
 		gfx::MdfMaterialFactory &mMdfFactory;
-		AasFreeListenerHandle mListenerHandle;
-		std::unordered_map<AasHandle, AasStatePtr> mRenderDataCache;
 		
 		// Shadow map related state
 		gfx::RenderTargetTexturePtr mShadowTarget; // Shadow map texture

--- a/Infrastructure/include/infrastructure/meshes.h
+++ b/Infrastructure/include/infrastructure/meshes.h
@@ -304,6 +304,11 @@ namespace gfx {
 		virtual gsl::span<uint16_t> GetIndices() = 0;
 	};
 
+	class IRenderState {
+	public:
+		virtual ~IRenderState() = default;
+	};
+
 	class AnimatedModel {
 	public:
 		virtual ~AnimatedModel() {
@@ -376,6 +381,27 @@ namespace gfx {
 			Scale is model scale in percent.
 		*/
 		virtual float GetRadius(int scale = 100) = 0;
+
+		/**
+		 * Sets a custom render state pointer that will be freed when this model is freed.
+		 */
+		virtual void SetRenderState(std::unique_ptr<IRenderState> renderState) = 0;
+
+		/**
+		 * Returns the currently assigned render state or null.
+		 */
+		virtual IRenderState *GetRenderState() const = 0;
+
+		template<typename T>
+		T &GetOrCreateRenderState() {
+			auto current = GetRenderState();
+			if (!current) {
+				auto newState = std::make_unique<T>();
+				current = newState.get();
+				SetRenderState(std::move(newState));
+			}
+			return (T&) *current;
+		}
 
 	};
 

--- a/Temple/Temple.vcxproj
+++ b/Temple/Temple.vcxproj
@@ -19,7 +19,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="include\temple\aasrenderer.h" />
     <ClInclude Include="include\temple\dll.h" />
     <ClInclude Include="include\temple\meshes.h" />
     <ClInclude Include="include\temple\materials.h" />
@@ -29,7 +28,6 @@
     <ClInclude Include="include\tig\texture.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\aasrenderer.cpp" />
     <ClCompile Include="src\dll.cpp" />
     <ClCompile Include="src\meshes.cpp" />
     <ClCompile Include="src\moviesystem.cpp" />
@@ -107,7 +105,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>include</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -145,7 +143,7 @@
       </PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>include</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/Temple/Temple.vcxproj.filters
+++ b/Temple/Temple.vcxproj.filters
@@ -30,9 +30,6 @@
     <ClInclude Include="include\temple\vfs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="include\temple\aasrenderer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="include\temple\moviesystem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -48,9 +45,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\vfs.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="src\aasrenderer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\moviesystem.cpp">

--- a/Temple/include/temple/meshes.h
+++ b/Temple/include/temple/meshes.h
@@ -17,9 +17,6 @@ namespace temple {
 		std::function<int(const std::string&)> resolveMaterial;
 	};
 
-	using AasFreeListener = std::function<void(AasHandle)>;
-	using AasFreeListenerHandle = std::list<AasFreeListener>::iterator;
-
 	class AasAnimatedModelFactory : public gfx::AnimatedModelFactory {
 	public:
 		explicit AasAnimatedModelFactory(const AasConfig &config);
@@ -45,11 +42,6 @@ namespace temple {
 		*/
 		std::unique_ptr<gfx::AnimatedModel> BorrowByHandle(AasHandle handle) override;
 
-		AasFreeListenerHandle AddFreeListener(AasFreeListener listener);
-		void RemoveFreeListener(AasFreeListenerHandle handle);
-
-		void InvalidateBuffers(AasHandle handle);
-
 		void FreeHandle(uint32_t handle) override;
 
 		void FreeAll() override;
@@ -59,7 +51,8 @@ namespace temple {
 		using FnAasModelFree = int(temple::AasHandle);
 		FnAasModelFree* mOrgModelFree;
 		static AasAnimatedModelFactory *sInstance;
-		std::list<AasFreeListener> mListeners;
+
+		std::unique_ptr<gfx::IRenderState> mRenderStates[5000];
 
 		// This is the mapping loaded from meshes.mes
 		std::unordered_map<int, std::string> mMapping;

--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -1085,7 +1085,7 @@ void LegacyCritterSystem::UpdateModelEquipment(objHndl obj)
 	// This is a bit shit but since AAS will just splice the
 	// add meshes into the list of model parts, 
 	// we have to reset the render buffers
-	gameSystems->GetAAS().InvalidateBuffers(model->GetHandle());
+	model->SetRenderState(nullptr);
 
 	// Apply the naked replacement materials for
 	// equipment slots that support them

--- a/TemplePlus/gamesystems/gamerenderer.cpp
+++ b/TemplePlus/gamesystems/gamerenderer.cpp
@@ -5,7 +5,7 @@
 #include <graphics/mdfmaterials.h>
 #include <graphics/shaperenderer2d.h>
 #include <fonts/fonts.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 #include <temple/dll.h>
 #include <particles/render.h>
 #include <particles/instances.h>
@@ -136,7 +136,7 @@ GameRenderer::GameRenderer(TigInitializer &tig,
 
 	Expects(!gameRenderer);
 
-	mAasRenderer = std::make_unique<temple::AasRenderer>(
+	mAasRenderer = std::make_unique<aas::Renderer>(
 		gameSystems.GetAAS(), 
 		tig.GetRenderingDevice(),
 		tig.GetShapeRenderer2d(),

--- a/TemplePlus/gamesystems/gamerenderer.h
+++ b/TemplePlus/gamesystems/gamerenderer.h
@@ -5,10 +5,8 @@ class TigInitializer;
 namespace gfx {
 	class RenderingDevice;
 }
-namespace temple {
-	struct AasConfig;
-	class AasAnimatedModelFactory;
-	class AasRenderer;
+namespace aas {
+	class Renderer;
 }
 namespace particles {
 	class ParticleRendererManager;
@@ -47,7 +45,7 @@ private:
 	gfx::RenderingDevice& mRenderingDevice;
 	GameSystems &mGameSystems;
 
-	std::unique_ptr<class temple::AasRenderer> mAasRenderer;
+	std::unique_ptr<aas::Renderer> mAasRenderer;
 	std::unique_ptr<MapObjectRenderer> mMapObjectRenderer;
 	std::unique_ptr<ParticleSystemsRenderer> mParticleSysRenderer;
 	std::unique_ptr<GMeshRenderer> mGmeshRenderer;

--- a/TemplePlus/gamesystems/gamesystems.h
+++ b/TemplePlus/gamesystems/gamesystems.h
@@ -37,8 +37,8 @@ private:
 
 class TigInitializer;
 
-namespace temple {
-	class AasAnimatedModelFactory;
+namespace gfx {
+	class AnimatedModelFactory;
 }
 
 class VagrantSystem;
@@ -452,7 +452,7 @@ public:
 		return mMapCloseAwareSystems;
 	}
 
-	temple::AasAnimatedModelFactory& GetAAS() const {
+	gfx::AnimatedModelFactory& GetAAS() const {
 		Expects(!!mAAS);
 		return *mAAS;
 	}
@@ -524,7 +524,7 @@ private:
 	GameSystemConf mConfig;
 	TigBufferstuffInitializer mTigBuffer;
 
-	std::unique_ptr<temple::AasAnimatedModelFactory> mAAS;
+	std::unique_ptr<gfx::AnimatedModelFactory> mAAS;
 	std::map<int, std::string> mMeshesById;
 
 	bool mResetting = false;

--- a/TemplePlus/gamesystems/map/gmesh.cpp
+++ b/TemplePlus/gamesystems/map/gmesh.cpp
@@ -85,7 +85,7 @@ void GMeshSystem::CloseMap() {
 	mFiles.clear();
 }
 
-GMeshRenderer::GMeshRenderer(temple::AasRenderer& aasRenderer, MapObjectRenderer& mapObjRenderer, GMeshSystem& gmeshSystem)
+GMeshRenderer::GMeshRenderer(aas::Renderer& aasRenderer, MapObjectRenderer& mapObjRenderer, GMeshSystem& gmeshSystem)
 	: mAasRenderer(aasRenderer), mMapObjRenderer(mapObjRenderer), mGmeshSystem(gmeshSystem) {
 }
 

--- a/TemplePlus/gamesystems/map/gmesh.h
+++ b/TemplePlus/gamesystems/map/gmesh.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include <infrastructure/meshes.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 
 #include "../../common.h"
 
@@ -47,14 +47,14 @@ private:
 
 class GMeshRenderer {
 public:
-	GMeshRenderer(temple::AasRenderer &aasRenderer,
+	GMeshRenderer(aas::Renderer &aasRenderer,
 		MapObjectRenderer &mapObjRenderer,
 		GMeshSystem &gmeshSystem);
 
 	void Render();
 
 private:
-	temple::AasRenderer &mAasRenderer;
+	aas::Renderer &mAasRenderer;
 	MapObjectRenderer &mMapObjRenderer;
 	GMeshSystem &mGmeshSystem;
 };

--- a/TemplePlus/gamesystems/mapobjrender.cpp
+++ b/TemplePlus/gamesystems/mapobjrender.cpp
@@ -12,7 +12,7 @@
 #include <infrastructure/images.h>
 #include <graphics/shaperenderer3d.h>
 #include <graphics/shaperenderer2d.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 #include "../critter.h"
 #include <graphics/dynamictexture.h>
 
@@ -49,7 +49,7 @@ static struct MapRenderAddresses : temple::AddressTable {
 MapObjectRenderer::MapObjectRenderer(GameSystems& gameSystems, 
 	gfx::RenderingDevice& device, 
 	gfx::MdfMaterialFactory &mdfFactory,
-	temple::AasRenderer &aasRenderer)
+	aas::Renderer &aasRenderer)
 	: mGameSystems(gameSystems),
 	  mDevice(device),
 	  mAasRenderer(aasRenderer) {

--- a/TemplePlus/gamesystems/mapobjrender.h
+++ b/TemplePlus/gamesystems/mapobjrender.h
@@ -11,8 +11,8 @@ namespace gfx {
 	using MdfRenderMaterialPtr = std::shared_ptr<class MdfRenderMaterial>;
 	using RenderTargetTexturePtr = std::shared_ptr<class RenderTargetTexture>;
 }
-namespace temple {
-	class AasRenderer;
+namespace aas {
+	class Renderer;
 }
 
 class GameSystems;
@@ -29,7 +29,7 @@ public:
 	MapObjectRenderer(GameSystems& gameSystems, 
 		gfx::RenderingDevice& device, 
 		gfx::MdfMaterialFactory &mdfFactory,
-		temple::AasRenderer &aasRenderer);
+		aas::Renderer &aasRenderer);
 	~MapObjectRenderer();
 
 	void RenderMapObjects(int tileX1, int tileX2, int tileY1, int tileY2);
@@ -66,7 +66,7 @@ public:
 private:
 	GameSystems& mGameSystems;
 	gfx::RenderingDevice& mDevice;
-	temple::AasRenderer &mAasRenderer;
+	aas::Renderer &mAasRenderer;
 	ShadowType mShadowType = ShadowType::ShadowMap;
 	gfx::MdfRenderMaterialPtr mBlobShadowMaterial;
 	gfx::MdfRenderMaterialPtr mHighlightMaterial;

--- a/Tools/MdfPreviewNative/native.cpp
+++ b/Tools/MdfPreviewNative/native.cpp
@@ -8,7 +8,7 @@
 #include <temple/vfs.h>
 #include <temple/dll.h>
 #include <temple/meshes.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 #include <graphics/buffers.h>
 #include <graphics/textures.h>
 #include <graphics/shaperenderer2d.h>
@@ -93,7 +93,7 @@ struct MdfPreviewNative {
 	std::unique_ptr<AasAnimatedModelFactory> aasFactory;
 	std::unique_ptr<ShapeRenderer2d> shapeRenderer2d;
 	std::unique_ptr<ShapeRenderer3d> shapeRenderer3d;
-	std::unique_ptr<AasRenderer> aasRenderer;
+	std::unique_ptr<aas::Renderer> aasRenderer;
 	std::unique_ptr<particles::PartSysParser> parser;
 	std::unique_ptr<particles::ParticleRendererManager> partSysRenderers;
 	std::unique_ptr<PartSysExternal> partSysExternal;
@@ -232,7 +232,7 @@ API void MdfPreviewNative_InitDevice(MdfPreviewNative *native,
 	native->shapeRenderer2d = std::make_unique<ShapeRenderer2d>(*native->device);
 	native->shapeRenderer3d = std::make_unique<ShapeRenderer3d>(*native->device);
 
-	native->aasRenderer = std::make_unique<AasRenderer>(*native->aasFactory, 
+	native->aasRenderer = std::make_unique<aas::Renderer>(*native->aasFactory, 
 		*native->device, 
 		*native->shapeRenderer2d,
 		*native->shapeRenderer3d,

--- a/Tools/ParticleEditorNative/ParticleEditorNative.cpp
+++ b/Tools/ParticleEditorNative/ParticleEditorNative.cpp
@@ -3,7 +3,7 @@
 #include <particles/render.h>
 #include <graphics/mdfmaterials.h>
 #include <graphics/textures.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 #include <temple/meshes.h>
 #include <temple/vfs.h>
 #include <fstream>

--- a/Tools/ParticleEditorNative/api.h
+++ b/Tools/ParticleEditorNative/api.h
@@ -11,7 +11,7 @@
 #include <graphics/shaperenderer3d.h>
 #include <infrastructure/meshes.h>
 #include <temple/meshes.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 #include <particles/render.h>
 
 struct TempleDll;
@@ -34,7 +34,7 @@ struct TempleDll {
 	gfx::ShapeRenderer2d shapeRenderer2d;
 	gfx::ShapeRenderer3d shapeRenderer3d;
 	temple::AasAnimatedModelFactory aasFactory;
-	temple::AasRenderer aasRenderer;
+	aas::Renderer aasRenderer;
 	particles::ParticleRendererManager renderManager;
 	std::unique_ptr<particles::PartSys> partSys;
 	gfx::AnimatedModelPtr currentModel;

--- a/Tools/ParticleEditorNative/video.cpp
+++ b/Tools/ParticleEditorNative/video.cpp
@@ -2,7 +2,7 @@
 #include <particles/instances.h>
 #include <particles/render.h>
 #include <graphics/device.h>
-#include <temple/aasrenderer.h>
+#include <aas/aas_renderer.h>
 #include <atlcomcli.h>
 #include <Shlwapi.h>
 


### PR DESCRIPTION
 (no dependency on temple.dll or lib).

This required a change to how render state is handled. Previously there was a temple.lib only mechanism of registering listeners on the deletion of AnimatedModels. What we now do instead is define an Interface with just a virtual destructor in the Infrastructure module and allow such objects (via unique_ptr) to be stored within the AnimatedModel directly.
Temple.lib now implements this interface by maintaining it's own array of render state internally.