### PR TITLE
Upscale Settings

### DIFF
--- a/Infrastructure/include/graphics/shaperenderer2d.h
+++ b/Infrastructure/include/graphics/shaperenderer2d.h
@@ -35,6 +35,14 @@ namespace gfx {
 	};
 #pragma pack(pop)
 	
+	enum class SamplerType2d {
+		CLAMP,
+		WRAP,
+		POINT
+	};
+
+	class SamplerState;
+
 	/*
 		Renders shapes in 2d screen space.
 	*/
@@ -43,8 +51,8 @@ namespace gfx {
 		explicit ShapeRenderer2d(RenderingDevice& g);
 		~ShapeRenderer2d();
 
-		void DrawRectangle(float x, float y, float width, float height, gfx::Texture& texture, uint32_t color = 0xFFFFFFFF) {
-			DrawRectangle(x, y, width, height, &texture, color);
+		void DrawRectangle(float x, float y, float width, float height, gfx::Texture& texture, uint32_t color = 0xFFFFFFFF, SamplerType2d samplerType = SamplerType2d::CLAMP) {
+			DrawRectangle(x, y, width, height, &texture, color, samplerType);
 		}
 		
 		void DrawRectangle(float x, float y, float width, float height, uint32_t color) {
@@ -54,7 +62,7 @@ namespace gfx {
 		void DrawRectangle(gsl::span<Vertex2d, 4> corners,
 			gfx::Texture* texture,
 			gfx::Texture* mask = nullptr,
-			bool wrap = false,
+			SamplerType2d samplerType = SamplerType2d::CLAMP,
 			bool blending = true);
 
 		void DrawRectangle(gsl::span<Vertex2d, 4> corners,
@@ -85,8 +93,11 @@ namespace gfx {
 		void DrawRectangle(
 			float x, float y, float width, float height,
 			gfx::Texture* texture,
-			uint32_t color = 0xFFFFFFFF
+			uint32_t color = 0xFFFFFFFF, 
+			SamplerType2d samplerType = SamplerType2d::CLAMP
 		);
+
+		SamplerState &getSamplerState(SamplerType2d type) const;
 
 		struct Impl;
 		std::unique_ptr<Impl> mImpl;

--- a/TemplePlus/config/config.cpp
+++ b/TemplePlus/config/config.cpp
@@ -180,7 +180,8 @@ static ConfigSetting configSettings[] = {
 	CONF_BOOL(fastSneakAnim),
 	CONF_BOOL(alertAiThroughDoors),
 	CONF_INT(walkDistanceFt),
-	CONF_BOOL(newAnimSystem)
+	CONF_BOOL(newAnimSystem),
+	CONF_BOOL(upscaleLinearFiltering)
 };
 
 void TemplePlusConfig::Load() {

--- a/TemplePlus/config/config.h
+++ b/TemplePlus/config/config.h
@@ -45,6 +45,7 @@ struct TemplePlusConfig
 	int windowHeight = 768;
 	int renderWidth = 800; // will set to window size on first run
 	int renderHeight = 600;
+	bool upscaleLinearFiltering = true;
 	std::wstring toeeDir;
 	int sectorCacheSize = 128; // Default is now 128 (ToEE was 16)
 	int screenshotQuality = 80; // 1-100, Default is 80

--- a/TemplePlus/graphics/render_hooks.cpp
+++ b/TemplePlus/graphics/render_hooks.cpp
@@ -416,8 +416,12 @@ int RenderHooks::TextureRender2d(const Render2dArgs* args) {
 	// rendering an icon
 	auto blending = ((args->flags & Render2dArgs::FLAG_DISABLEBLENDING) == 0);
 
-	auto wrap = ((args->flags & Render2dArgs::FLAG_WRAP) != 0);
-	shapeRenderer.DrawRectangle(vertices, deviceTexture, maskTexture, wrap, blending);
+	gfx::SamplerType2d samplerType = gfx::SamplerType2d::CLAMP;
+	if ((args->flags & Render2dArgs::FLAG_WRAP) != 0) {
+		samplerType = gfx::SamplerType2d::WRAP;
+	}
+
+	shapeRenderer.DrawRectangle(vertices, deviceTexture, maskTexture, samplerType, blending);
 	
 	return 0;
 }

--- a/TemplePlus/mainloop.cpp
+++ b/TemplePlus/mainloop.cpp
@@ -269,12 +269,19 @@ void GameLoop::RenderFrame() {
 	TigRect srcRect{0, 0, config.renderWidth, config.renderHeight};
 	srcRect.FitInto(destRect);
 
+	gfx::SamplerType2d samplerType = gfx::SamplerType2d::CLAMP;
+	if (!config.upscaleLinearFiltering) {
+		samplerType = gfx::SamplerType2d::POINT;
+	}
+
 	tig->GetShapeRenderer2d().DrawRectangle(
 		(float) srcRect.x, 
 		(float)srcRect.y, 
 		(float)srcRect.width, 
 		(float)srcRect.height, 
-		*mSceneColor
+		*mSceneColor,
+		0xFFFFFFFF,
+		samplerType
 	);
 
 	tig->GetConsole().Render();


### PR DESCRIPTION
Implemented a setting that allows the scene to be upscaled without linear filtering, which might work better if the render scene is exactly half the size of the screen for example (leading to less blur).