### PR TITLE
Fix multiple small mistakes in AI

### DIFF
--- a/TemplePlus/ai.cpp
+++ b/TemplePlus/ai.cpp
@@ -4280,7 +4280,7 @@ void AiPacket::DoWaypoints(){
 		return;
 	}
 
-	if (npcFlags && ONF_AI_WAIT_HERE)
+	if (npcFlags & ONF_AI_WAIT_HERE)
 		return;
 
 	if (gameSystems->GetAnim().GetFirstRunSlotId(obj))

--- a/TemplePlus/ai.cpp
+++ b/TemplePlus/ai.cpp
@@ -1280,7 +1280,7 @@ BOOL AiSystem::TargetDamaged(AiTactic * aiTac){
 BOOL AiSystem::TargetFriendHurt(AiTactic * aiTac)
 {
 	auto performer = aiTac->performer;
-	auto lowest = 0.7;
+	auto lowest = 70;
 	auto N = combatSys.GetInitiativeListLength();
 	for (auto i = 0; i < N; i++) {
 		auto combatant = combatSys.GetInitiativeListMember(i);

--- a/TemplePlus/ai.cpp
+++ b/TemplePlus/ai.cpp
@@ -4266,7 +4266,7 @@ void AiPacket::DoWaypoints(){
 	if (!this->leader){
 		if (npcFlags& ONF_USE_ALERTPOINTS){
 			
-			if (!!temple::GetRef<BOOL(__cdecl)(objHndl, int)>(0x1005BC00)(obj, 0)){
+			if (!temple::GetRef<BOOL(__cdecl)(objHndl, int)>(0x1005BC00)(obj, 0)){
 				gameSystems->GetAnim().PushFidget(obj);
 				temple::GetRef<void(__cdecl)(objHndl)>(0x10015FD0)(obj);
 			}


### PR DESCRIPTION
Fixed a few small mistakes in the AI code that I came across.

- The lowest HP percentage was at 0.7 (from Vanilla), but Vanilla used fractions for HP percentages, while GetHPPercentage will return a real percentage (100 for full HP). Changed to 70 to compensate.
- Fixed a double negation for waypoint code, I checked the asm @ 0x1005c6f0 and I think this is a typo.
- Same function will auto-exit and not run the code after `&& ONF_AI_WAIT_HERE`, I also think this is a typo.