### PR TITLE
game.combat_turn and Path constructors fix

### DIFF
--- a/TemplePlus/animgoals/animgoals_callbacks.cpp
+++ b/TemplePlus/animgoals/animgoals_callbacks.cpp
@@ -84,7 +84,7 @@ int GoalIsProne(AnimSlot& slot)
 int GoalIsConcealed(AnimSlot& slot)
 {
 	//logger->debug("GoalState IsConcealed");
-	return (critterSys.IsConcealed(slot.param1.obj));
+	return (objects.IsCritter(slot.param1.obj) && critterSys.IsConcealed(slot.param1.obj));
 }
 
 // Originally @ 0x100125F0

--- a/TemplePlus/combat.cpp
+++ b/TemplePlus/combat.cpp
@@ -1859,6 +1859,11 @@ bool LegacyCombatSystem::TripCheck(objHndl handle, objHndl target){
 
 	return succeeded;
 }
+
+int LegacyCombatSystem::GetCombatRoundCount()
+{
+	return *combatAddresses.combatRoundCount;
+}
 #pragma endregion
 
 

--- a/TemplePlus/combat.h
+++ b/TemplePlus/combat.h
@@ -106,6 +106,7 @@ struct LegacyCombatSystem : temple::AddressTable {
 	void ToHitProcessing(D20Actn &d20a);
 	bool TripCheck(objHndl handle, objHndl target);
 
+	int GetCombatRoundCount();
 	LegacyCombatSystem() {
 		rebase(combatModeActive, 0x10AA8418);
 		rebase(combatMesfileIdx, 0x10AA8408);

--- a/TemplePlus/pathfinding.h
+++ b/TemplePlus/pathfinding.h
@@ -133,12 +133,20 @@ struct Path {
 
 	// Returns the next node along this path, or empty in case the path is not completely built
 	std::optional<LocAndOffsets> GetNextNode() const;
+
+	Path() {
+		memset(this, 0, sizeof(Path));
+	}
 };
 
 struct PathQueryResult : Path {
 	// Sometimes, a pointer to the following two values is passed as "pPauseTime" (see 100131F0)
 	int occupiedFlag;
 	int someDelay;
+
+	PathQueryResult() {
+		memset(this, 0, sizeof(PathQueryResult));
+	}
 };
 
 struct PathResultCache : PathQuery

--- a/TemplePlus/python/python_game.cpp
+++ b/TemplePlus/python/python_game.cpp
@@ -238,6 +238,11 @@ static int PyGame_SetNewSid(PyObject *obj, PyObject *value, void*) {
 	return 0;
 }
 
+static PyObject* PyGame_GetCombatTurn(PyObject* obj, void*) {
+	auto result = combatSys.GetCombatRoundCount();
+	return PyInt_FromLong(result);
+}
+
 
 static PyGetSetDef PyGameGettersSetters[] = {
 	{"party_alignment", PyGame_GetPartyAlignment, NULL, NULL },
@@ -259,6 +264,7 @@ static PyGetSetDef PyGameGettersSetters[] = {
 	{"areas", PyGame_GetAreas, NULL, NULL},
 	{"counters", PyGame_GetCounters, NULL, NULL},
 	{"encounter_queue", PyGame_GetEncounterQueue, NULL, NULL},
+	{"combat_turn", PyGame_GetCombatTurn, NULL, NULL},
 	{NULL, NULL, NULL, NULL}
 };
 

--- a/TemplePlus/python/python_object.cpp
+++ b/TemplePlus/python/python_object.cpp
@@ -620,7 +620,6 @@ static PyObject* PyObjHandle_CanFindPathToObj(PyObject* obj, PyObject* args) {
 	pathQ.distanceToTargetMin = 0.0;
 	pathQ.tolRadius = reach * 12.0f - fourPointSevenPlusEight;
 
-	pqr.nodeCount = 0;
 	auto nodeCount = pathfindingSys.FindPath(&pathQ, &pqr);
 	
 	auto pathLen = pathfindingSys.GetPathLength(&pqr);

--- a/TemplePlus/traps.h
+++ b/TemplePlus/traps.h
@@ -22,10 +22,10 @@ struct Trap {
 	ObjScriptEvent trigger; // Which script event triggers it?
 	int flags; // see TrapFlag
 	char *partSysName;
-	int unk1;
-	int unk2;
+	int searchDC;
+	int disableDC;
 	char *replaceWith; // If the obj is not a "real" trap, the trap script will be replaced by this trap after triggering (by name)
-	BOOL unkCol12; // second to last col
+	int CR; // second to last col
 	int damageCount;
 	TrapDamage damage[5];
 };

--- a/TemplePlus/ui/ui_intgame_turnbased.cpp
+++ b/TemplePlus/ui/ui_intgame_turnbased.cpp
@@ -1008,7 +1008,7 @@ void UiIntgameTurnbased::CursorRenderUpdate(){
 		cursorState = specialCursor;
 
 	if (cursorState != cursorPrevState){
-		logger->debug("Changing cursor from {} to {}", cursorState, cursorPrevState);
+		//logger->debug("Changing cursor from {} to {}", cursorState, cursorPrevState);
 		if (cursorPrevState)
 			temple::GetRef<void(__cdecl)()>(0x101DD770)();
 


### PR DESCRIPTION
* pathfinding.h - better fix of PathQueryResult.nodeCount not initializing;
* python_game.cpp - added game.combat_round Python API;
* ui_intgame_turnbased.cpp - remove obsolate debug print;
* animgoals_callbacks - fixed IsConcealed on non-critter;
* traps.h - figured out  unknown fields in Trap;