### PR TITLE
tpdp.dispatch_skill and other Python API changes

### DIFF
--- a/TemplePlus/common.h
+++ b/TemplePlus/common.h
@@ -100,6 +100,13 @@ struct BonusEntry
 	int32_t bonType; // types 0, 8 and 21 can stack ( 100E6490 ); use negative number for modifier
 	const char * bonusMesString; // parsable string for the help system e.g. "~Item~[TAG_ITEM]"
 	char * bonusDescr; // e.g. "Magic Full Plate +1"
+
+	BonusEntry() {
+		this->bonValue = 0;
+		this->bonType = 0;
+		this->bonusMesString = nullptr;
+		this->bonusDescr = nullptr;
+	}
 };
 
 struct BonusCap
@@ -108,6 +115,13 @@ struct BonusCap
 	int bonType;
 	char *bonCapperString;
 	const char * bonCapDescr;
+
+	BonusCap() {
+		this->capValue = 0;
+		this->bonType = 0;
+		this->bonCapperString = nullptr;
+		this->bonCapDescr = nullptr;
+	}
 };
 
 struct BonusList

--- a/TemplePlus/poison.cpp
+++ b/TemplePlus/poison.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <gamesystems\gamesystems.h>
 #include <combat.h>
+#include <gamesystems\d20\d20stats.h>
 
 static class PoisonFixes : public TempleFix
 {
@@ -180,6 +181,11 @@ int PoisonFixes::PoisonedOnAdd(DispatcherCallbackArgs args) {
 
 	auto rollRes = Dice(pspec->immNumDie, pspec->immDieType, pspec->immDieBonus).Roll();
 	conds.AddTo(args.objHndCaller, "Temp_Ability_Loss", { pspec->immediateEffect + (pspec->immediateEffect < 0 ? 6 : 0), rollRes });
+	{
+		Stat stat = (Stat)abs(pspec->immediateEffect);
+		auto statName = d20Stats.GetStatShortName(stat);
+		histSys.CreateFromFreeText(fmt::format("{} takes {} {} damage from poison!\n", description.getDisplayName(args.objHndCaller), rollRes, statName).c_str());
+	}
 
 	if (pspec->immediateSecondEffect != (int)PoisonEffect::None) {
 		rollRes = Dice(pspec->immSecDice.count, pspec->immSecDice.sides, pspec->immSecDice.bonus).Roll();

--- a/TemplePlus/python/python_dispatcher.cpp
+++ b/TemplePlus/python/python_dispatcher.cpp
@@ -30,6 +30,7 @@
 #include "temple_functions.h"
 #include "rng.h"
 #include "float_line.h"
+#include "history.h"
 
 namespace py = pybind11;
 
@@ -141,6 +142,19 @@ PYBIND11_EMBEDDED_MODULE(tpdp, m) {
 
 		tio_filelist_destroy(&flist);
 		return result;
+	});
+
+	m.def("dispatch_skill", [](objHndl obj, uint32_t skill_enum, BonusList& bonList, objHndl obj2 = objHndl::null, uint32_t flag = 1)-> int {
+		auto skillLevel = dispatch.dispatch1ESkillLevel(obj, (SkillEnum)skill_enum, (BonusList*)&bonList, obj2, flag);
+		return skillLevel;
+	});
+
+	m.def("create_history_type6_opposed_check", [](objHndl performer, objHndl defender, int performerRoll, int defenderRoll
+		, BonusList& performerBonList, BonusList& defenderBonList, uint32_t combatMesLineTitle, uint32_t combatMesLineResult, uint32_t flag)-> int
+	{
+		auto rollHistId = histSys.RollHistoryAddType6OpposedCheck(performer, defender, performerRoll, defenderRoll
+			, (BonusList*)&performerBonList, (BonusList*)&defenderBonList, combatMesLineTitle, combatMesLineResult, flag);
+		return rollHistId;
 	});
 
 	#pragma region Basic Dispatcher stuff
@@ -715,6 +729,10 @@ PYBIND11_EMBEDDED_MODULE(tpdp, m) {
 		.def_readwrite("return_val", &DispIoD20Signal::return_val)
 		.def_readwrite("data1", &DispIoD20Signal::data1)
 		.def_readwrite("data2", &DispIoD20Signal::data2)
+		.def("get_d20_action", [](DispIoD20Signal& evtObj)->D20Actn& {
+			D20Actn* d20a = (D20Actn*)evtObj.data1;
+			return *d20a;
+		}, "Used to get a D20Action from the data1 field")
 		;
 
 	py::class_<DispIoD20Query, DispIO>(m, "EventObjD20Query")

--- a/TemplePlus/python/python_game.cpp
+++ b/TemplePlus/python/python_game.cpp
@@ -48,6 +48,7 @@
 #include "ui/ui_worldmap.h"
 #include "ui/ui_char.h"
 #include "infrastructure/elfhash.h"
+#include "ui/ui_alert.h"
 
 #include <pybind11/embed.h>
 namespace py = pybind11;
@@ -1310,6 +1311,18 @@ static PyObject* PyGame_GetObjById(PyObject*, PyObject* args) {
 	return PyObjHndl_Create(handle);
 }
 
+PyObject* PyGame_AlertShow(PyObject*, PyObject* args) {
+	char* text, *button_text;
+	if (!PyArg_ParseTuple(args, "ss:game.alert_show", &text, &button_text)) {
+		return 0;
+	}
+	if (!text || !button_text) {
+		return 0;
+	}
+	auto result = UiAlert::ShowEx(2, 0, 0, button_text, text);
+	return PyInt_FromLong(result);
+}
+
 static PyMethodDef PyGameMethods[]{
 	{ "get_wall_endpt", PySpell_SpellGetPickerEndPoint, METH_VARARGS, NULL },
 	{ "create_history_freeform", PyGame_CreateHistoryFreeform, METH_VARARGS, NULL },
@@ -1384,6 +1397,7 @@ static PyMethodDef PyGameMethods[]{
 	{"is_melee_weapon", PyGame_IsMeleeWeapon,METH_VARARGS, NULL},
 	{"make_custom_name", PyGame_MakeCustomName,METH_VARARGS, NULL},
 	{"get_obj_by_id", PyGame_GetObjById, METH_VARARGS, NULL},
+	{"alert_show", PyGame_AlertShow, METH_VARARGS, NULL},
 	// This is some unfinished UI for which the graphics are missing
 	// {"charmap", PyGame_Charmap, METH_VARARGS, NULL},
 	{NULL, NULL, NULL, NULL}

--- a/TemplePlus/python/python_integration_encounter.cpp
+++ b/TemplePlus/python/python_integration_encounter.cpp
@@ -25,6 +25,11 @@ can rest in the current area.
 */
 void UpdateSleepStatus() {
 	auto result = pythonObjIntegration.ExecuteScript("random_encounter", "can_sleep");
+	if (!result) {
+		logger->error("Unable to check for a random encounter - can_sleep");
+		PyErr_Print();
+	}
+
 	if (result) {
 		*addresses.sleepStatus = PyInt_AsLong(result);
 		Py_DECREF(result);

--- a/TemplePlus/ui/ui_alert.cpp
+++ b/TemplePlus/ui/ui_alert.cpp
@@ -9,3 +9,10 @@ int UiAlert::Show(int helpId, int(*callback)(int), const char * btnText)
 	return temple::GetRef<int(__cdecl)(int, int(*)(int), const char*)>(0x100E6F10)(helpId, callback, btnText);
 	return 0;
 }
+
+int UiAlert::ShowEx(int showType, int helpId, int(*callback)(int), const char* btnText, char* text)
+{
+	UiAlertSpec promptMini = { showType, helpId, text };
+	// UiAlertShow_Impl
+	return temple::GetRef<int(__cdecl )(UiAlertSpec*, int(*)(int), const char*)>(0x1009ABA0)(&promptMini, callback, btnText);
+}

--- a/TemplePlus/ui/ui_alert.h
+++ b/TemplePlus/ui/ui_alert.h
@@ -2,17 +2,19 @@
 
 struct UiAlertSpec
 {
-	int type;
+	int type; // 0 - get help topic from helpId; 1 - get help topic from helpId put into history; 2 - simply show .->text;
 	int helpId; // hash of help.tab string (TAG_XXX )
 	char *text;
 };
 
 class UiAlert
 {
+public:
 	/*
 		shows a simple alert box, with content taken from the help.tab file
 	*/
 	int Show(int helpId, int(__cdecl*callback)(int), const char *btnText);
+	static int ShowEx(int showType, int helpId, int(*callback)(int), const char* btnText, char* text);
 };
 
 


### PR DESCRIPTION
* common.h - added constructors for BonusEntry and BonusCap;
* poison.cpp - added history line when damage is dealt for ability loss. Was unclear;
* python_dispatcher.cpp - added dispatch_skill to get bonuse list;
* python_dispatcher.cpp - added create_history_type6_opposed_check, tested thoroughly;
* python_dispatcher.cpp - added EventObjD20Signal.get_d20_action, see ActionSequenceSystem::ActionBroadcastAndSignalMoved()
* python_game.cpp - added game.alert_show;
* python_integration_encounter.cpp - added python error print for can_sleep;
* ui_alert - UiAlert::ShowEx implementation;