### PR TITLE
Worldmap fixes

### DIFF
--- a/TemplePlus/fade.h
+++ b/TemplePlus/fade.h
@@ -6,6 +6,7 @@ enum FadeAndTeleportFlags : uint32_t {
 	ftf_advance_time = 8,
 	ftf_play_sound = 0x10,
 	ftf_unk20 = 0x20,
+	ftf_unk200 = 0x200,
 	ftf_unk80000000 = 0x80000000
 };
 

--- a/TemplePlus/gamesystems/legacysystems.cpp
+++ b/TemplePlus/gamesystems/legacysystems.cpp
@@ -2064,6 +2064,27 @@ const std::string &RandomEncounterSystem::GetName() const {
 	return name;
 }
 
+int RandomEncounterSystem::GetTerrainType(int x, int y)
+{
+	auto result = 0;
+	auto bitmapW = temple::GetRef<int>(0x109DD338 + 0x50C);
+	auto bitmapH = temple::GetRef<int>(0x109DD338 + 0x510);
+	auto bitmapData = temple::GetRef<unsigned char*>(0x109DD338 + 0x508);
+	auto offset = x * bitmapW / 528
+		+ bitmapW * (y * bitmapH / 565);
+	if (offset < 0){
+		offset = 0;
+	}
+	else if (offset >= bitmapW * bitmapH){
+		offset = bitmapW * bitmapH - 1;
+	}
+	if (offset & 1)
+		result = bitmapData[offset >> 1] >> 4;
+	else
+		result = bitmapData[offset >> 1] & 0xF;
+	return result;
+}
+
 //*****************************************************************************
 //* ObjectEvent
 //*****************************************************************************

--- a/TemplePlus/gamesystems/legacysystems.h
+++ b/TemplePlus/gamesystems/legacysystems.h
@@ -608,6 +608,7 @@ public:
 	bool SaveGame(TioFile *file) override;
 	bool LoadGame(GameSystemSaveFile* saveFile) override;
 	const std::string &GetName() const override;
+	int GetTerrainType(int x, int y);
 };
 
 class ObjectEventSystem : public GameSystem, public SaveGameAwareGameSystem, public ResetAwareGameSystem, public TimeAwareGameSystem {

--- a/TemplePlus/python/python_integration_encounter.cpp
+++ b/TemplePlus/python/python_integration_encounter.cpp
@@ -5,6 +5,8 @@
 #include <structmember.h>
 #include <party.h>
 #include <gamesystems/random_encounter.h>
+#include "gamesystems/gamesystems.h"
+#include "gamesystems/legacysystems.h"
 
 static struct PyRandomEncounterAddresses : temple::AddressTable {
 	int* sleepStatus;
@@ -211,7 +213,8 @@ static void __cdecl RandomEncounterCreate(RandomEncounter* encounter) {
 */
 static BOOL __cdecl RandomEncounterExists(const RandomEncounterSetup* setup, RandomEncounter **pEncounterOut) {
 	auto args = PyTuple_New(2);
-	auto terrain = addresses.GetTerrainType(setup->location);
+	auto terrain = gameSystems->GetRandomEncounter().GetTerrainType((int)setup->location.locx, (int)setup->location.locy);
+	//auto terrain = addresses.GetTerrainType(setup->location);
 	PyTuple_SET_ITEM(args, 0, PyRandomEncounterSetup_Create(terrain, setup->flags));
 	auto encounter = PyRandomEncounter_Create();
 	// Flag 1 means "sleep encounter"

--- a/TemplePlus/ui/ui_worldmap.cpp
+++ b/TemplePlus/ui/ui_worldmap.cpp
@@ -36,6 +36,7 @@ public:
 };
 
 constexpr int ACQUIRED_LOCATIONS_CO8 = 21;
+constexpr int TRAILDOT_MAX = 80;
 struct WorldmapWidgetsCo8
 {
 	LgcyWindow * mainWnd;
@@ -45,7 +46,7 @@ struct WorldmapWidgetsCo8
 	LgcyButton * locationRingBtns[14];
 	LgcyButton * scriptBtns[14];
 	LgcyButton * URHereBtn;
-	LgcyButton * trailDots[80];
+	LgcyButton * trailDots[TRAILDOT_MAX];
 	LgcyButton * exitBtn;
 	LgcyWindow * selectionWnd;
 	LgcyButton * acquiredLocations[ACQUIRED_LOCATIONS_CO8];
@@ -171,6 +172,7 @@ public:
 		replaceFunction<void()>(0x1015EA20, UiWorldmapMakeTripWrapper);
 		
 		// UiWorldmapAcquiredLocationBtnMsg 
+		if (false)
 		static BOOL(__cdecl*orgUiWorldmapAcquiredLocationBtnMsg)(LgcyWidgetId, TigMsg *) = replaceFunction<BOOL(__cdecl)(LgcyWidgetId, TigMsg *)>(0x1015F320, [](LgcyWidgetId widId, TigMsg *msg){
 			
 			if (msg->type == TigMsgType::MOUSE){
@@ -412,68 +414,15 @@ int WorldmapFix::CanAccessWorldmap()
 	return result;
 }
 
-BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
-	auto &mTeleportMapId = temple::GetRef<int>(0x102FB3CC);
-	auto &mTeleportMapIdTable = temple::GetRef<int[ACQUIRED_LOCATIONS_CO8]>(0x11EA3710);
-	auto &mToId = temple::GetRef<int>(0x102FB3E0);
-	auto &mFromId = temple::GetRef<int>(0x102FB3E4);
-	auto & mIsMakingTrip = temple::GetRef<int>(0x10BEF7FC);
-	auto &mRandomEncounterStatus = temple::GetRef<int>(0x102FB3D0);
-	auto &mTrailDotInitialIdx = temple::GetRef<int>(0x102FB3DC);
-	auto &mTrailDotCount = temple::GetRef<int>(0x10BEF7F8);
-	auto &mXoffset = temple::GetRef<int>(0x102FB3EC);
-	auto &mYoffset = temple::GetRef<int>(0x102FB3F0);
-	auto &someX_10BEF7CC = temple::GetRef<int>(0x10BEF7CC);
-	auto &someY_10BEF7D0 = temple::GetRef<int>(0x10BEF7D0);
-	auto &mRandomEncounterX = temple::GetRef<int>(0x102FB3D4);
-	auto &mRandomEncounterY = temple::GetRef<int>(0x102FB3D8);
-	auto & mWorldmapWidgets = temple::GetRef<WorldmapWidgetsCo8*>(0x10BEF2D0);
-	auto &mWorldmapState = temple::GetRef<int>(0x10BEF808);
-	auto &mPaths = temple::GetRef<WorldmapPath[190]>(0x11EA2406);
-
-	constexpr int PATH_ID_TABLE_WIDTH = 20;
-	auto &mPathIdTable = temple::GetRef<int[PATH_ID_TABLE_WIDTH*PATH_ID_TABLE_WIDTH]>(0x11EA4100);
-
-	mTeleportMapId = mTeleportMapIdTable[toId];
-	auto toId_adj = toId;
-	if ( fromId == -1 ){
-		toId_adj = mToId;
-	}
-	else{
-		mFromId = fromId;
-		if (fromId == 10 || fromId == 11){
-			mFromId = 9;
-		}
-		else if (fromId == 12 || fromId == 13){
-			mFromId = 6;
-		}
-		toId_adj = toId;
-		mToId = toId;
-		if (toId == 10 || toId == 11 ){
-			mToId = toId_adj = 9;
-		}
-		else if (toId == 12 || toId == 13){
-			mToId = toId_adj = 6;
-		}
-	}
-	mIsMakingTrip = 1;
-	
-	if (fromId == 10 || fromId == 11){
-		fromId = 9;
-	}
-	else if (fromId == 12 || fromId == 13) {
-		fromId = 6;
-	}
-
-	if (toId == 10 || toId == 11){
-		toId = 9;
-	}
-	else if (toId == 12 || toId == 13) {
-		toId = 6;
-	}
-
-	auto toX = 0, toY = 0;
-	switch (toId){
+int convertSpecialId(int id) {
+	if (id == 10 || id == 11)
+		return 9;
+	if (id == 12 || id == 13)
+		return 6;
+	return id;
+};
+void GetWorldXyById(int id, int& toX, int&toY){
+	switch (id) {
 	case 0:
 		toX = temple::GetRef<int>(0x10BEF3B4);
 		toY = temple::GetRef<int>(0x10BEF3B8);
@@ -523,11 +472,55 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 		toY = temple::GetRef<int>(0x10BEF57C);
 		break;
 	default:
-		break;
+		toX = toY = 0;
 	}
+}
 
-	// If exiting a random encounter
-	if (mRandomEncounterStatus == 2 && toId != toId_adj && toId != mFromId ){
+BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
+	auto &mTeleportMapId = temple::GetRef<int>(0x102FB3CC);
+	auto &mTeleportMapIdTable = temple::GetRef<int[ACQUIRED_LOCATIONS_CO8]>(0x11EA3710);
+	auto &mToId = temple::GetRef<int>(0x102FB3E0);
+	auto &mFromId = temple::GetRef<int>(0x102FB3E4);
+	auto & mIsMakingTrip = temple::GetRef<int>(0x10BEF7FC);
+	auto &mRandomEncounterStatus = temple::GetRef<int>(0x102FB3D0);
+	auto &mTrailDotInitialIdx = temple::GetRef<int>(0x102FB3DC);
+	auto &mTrailDotCount = temple::GetRef<int>(0x10BEF7F8);
+	auto &mXoffset = temple::GetRef<int>(0x102FB3EC);
+	auto &mYoffset = temple::GetRef<int>(0x102FB3F0);
+	auto &someX_10BEF7CC = temple::GetRef<int>(0x10BEF7CC);
+	auto &someY_10BEF7D0 = temple::GetRef<int>(0x10BEF7D0);
+	auto &mRandomEncounterX = temple::GetRef<int>(0x102FB3D4);
+	auto &mRandomEncounterY = temple::GetRef<int>(0x102FB3D8);
+	auto & mWorldmapWidgets = temple::GetRef<WorldmapWidgetsCo8*>(0x10BEF2D0);
+	auto &mWorldmapState = temple::GetRef<int>(0x10BEF808);
+	auto &mPaths = temple::GetRef<WorldmapPath[190]>(0x11EA2406);
+
+
+
+	constexpr int PATH_ID_TABLE_WIDTH = 20;
+	auto &mPathIdTable = temple::GetRef<int[PATH_ID_TABLE_WIDTH*PATH_ID_TABLE_WIDTH]>(0x11EA4100);
+
+	mTeleportMapId = mTeleportMapIdTable[toId];
+	auto toIdOrg = toId;
+	if ( fromId == -1 ){ // random encounter map
+		toIdOrg = mToId;
+	}
+	else{
+		mFromId = fromId = convertSpecialId(fromId);
+		mToId = toIdOrg = toId = convertSpecialId(toId);
+	}
+	mIsMakingTrip = 1;
+	
+	fromId = convertSpecialId(fromId);
+	toId = convertSpecialId(toId);
+	
+	auto toX = 0, toY = 0;
+	GetWorldXyById(toId, toX, toY);
+	
+
+	// If exiting a random encounter and going to a different location than origin/prev. destination
+	// Make a beeline path
+	if (mRandomEncounterStatus == 2 && toId != toIdOrg && toId != mFromId ){
 		auto fromX = mXoffset + someX_10BEF7CC + mRandomEncounterX + 10;
 		auto fromY = mYoffset + someY_10BEF7D0 + mRandomEncounterY + 10;
 		logger->info("Travelling on the map from {}, {} to {}, {}", fromX, fromY, toX, toY);
@@ -539,6 +532,9 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 		auto deltaX = fromX - toX;
 		auto deltaY = fromY - toY;
 		mTrailDotCount = sqrt(deltaY*deltaY + deltaX * deltaX) / 12 + 1;
+		if (mTrailDotCount >= TRAILDOT_MAX){ // fixes crash
+			mTrailDotCount = 80;
+		}
 		auto sumX = 0, sumY = 0;
 		for (auto i = 0; i <= mTrailDotCount; ++i){
 			auto dotWidget = mWorldmapWidgets->trailDots[i];
@@ -560,7 +556,7 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 		return FALSE;
 	}
 
-	auto v44 = false, v49 = false;
+	auto rePathForward = false, rePathBackward = false;
 	auto endTrip = true;
 	if (mWorldmapState != 1){
 		endTrip = false;
@@ -573,12 +569,12 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 		}
 		else if (mRandomEncounterStatus == 2){
 			if (toId == mFromId){
-				fromId = toId_adj;
-				v49 = true;
+				fromId = toIdOrg;
+				rePathBackward = true;
 			}
-			else if (toId == toId_adj){
+			else if (toId == toIdOrg){
 				fromId = mFromId;
-				v44 = true;
+				rePathForward = true;
 			}
 		}
 	}
@@ -610,7 +606,7 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 				traildot->x = wmPath.startX + deltaX;
 				traildot->y = wmPath.startY + deltaY;
 				auto dotIdx = 1;
-				for (auto i = 1; i < wmPath.count; ++i) {
+				for (auto i = 1; i <= wmPath.count; ++i) {
 					traildot = mWorldmapWidgets->trailDots[dotIdx];
 					switch (wmPath.directions[i - 1]) {
 					case 5:
@@ -637,7 +633,10 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 						traildot->y = deltaY + wmPath.startY;
 						dotIdx++;
 					}
-
+					if (dotIdx >= TRAILDOT_MAX){
+						break;
+					}
+						
 				}
 			}
 			else{
@@ -656,7 +655,7 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 				traildot->x = wmPath.startX + deltaX;
 				traildot->y = wmPath.startY + deltaY;
 				auto dotIdx = 1;
-				for (auto i = 1; i < wmPath.count; ++i) {
+				for (auto i = 1; i <= wmPath.count; ++i) {
 					traildot = mWorldmapWidgets->trailDots[mTrailDotCount- dotIdx];
 					switch (wmPath.directions[i - 1]) {
 					case 5:
@@ -683,14 +682,16 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 						traildot->y = deltaY + wmPath.startY;
 						++dotIdx;
 					}
-
+					if (dotIdx >= TRAILDOT_MAX) {
+						break;
+					}
 				}
 			}
 
 
 			
 
-			if (v44){
+			if (rePathForward){
 				auto dotDelta = mTrailDotCount - mTrailDotInitialIdx;
 				mTrailDotCount = dotDelta;
 				auto dotCount = dotDelta + 1;
@@ -701,7 +702,7 @@ BOOL WorldmapFix::UiWorldmapMakeTripCdecl(int fromId, int toId) {
 					dotsDest->y = dotsSrc->y;
 				}
 			}
-			else if (v49){
+			else if (rePathBackward){
 				auto dotDelta = mTrailDotCount - mTrailDotInitialIdx;
 				mTrailDotCount = mTrailDotInitialIdx;
 				auto dotCount = mTrailDotInitialIdx + 1;

--- a/TemplePlus/ui/ui_worldmap.h
+++ b/TemplePlus/ui/ui_worldmap.h
@@ -16,10 +16,12 @@ public:
 	const std::string &GetName() const override;
 
 	void Show(int mode);
+	void Hide();
 
 	// Called by the dialog scripts to travel to an area based on a dialog choice
 	void TravelToArea(int area);
 	bool NeedToClearEncounterMap();
+	
 private:
 	std::unique_ptr<UiWorldmapImpl> mImpl;
 };


### PR DESCRIPTION
@doug1234 
That's one of the WIP fixes I'd wanted for the next release.
IIRC there were two issues actually:
1. Travelling to one of the new Co8 locations from a random encounter map, when it's not the original destination of travel. See thread:
https://co8.org/community/index.php?threads/release-dllfix11.3940/
I think that's fully fixed.
2. Crash due to getting data from the terrain bitmap wrong. See thread:
https://co8.org/community/index.php?threads/terrain-bmp.11642/#post-148308
I think I fixed the immediate crash issue by reploacing the GetTerrainType func and making it safe. But I think I was having some trouble calculating the offsets into the bmp data in memory. As it is, Co8 ignores it anyway and just randomizes the terrain, but it'd be nice to make the worldmap bitmap great again.
