### PR TITLE
Fixed bug in aas_anim_player 

### DIFF
--- a/Infrastructure/src/aas/aas_anim_player.cpp
+++ b/Infrastructure/src/aas/aas_anim_player.cpp
@@ -402,7 +402,7 @@ namespace aas {
 	static std::optional<AnimEventType> GetEventType(std::string_view type) {
 		if (!_stricmp(type.data(), "script")) {
 			return AnimEventType::Script;
-		} else if (_stricmp(type.data(), "end")) {
+		} else if (!_stricmp(type.data(), "end")) {
 			return AnimEventType::End;
 		} else if (!_stricmp(type.data(), "action")) {
 			return AnimEventType::Action;


### PR DESCRIPTION
Bug in GetEventType - prevented spells from firing, among other things.
(this only affected the game when configured with newAnimSystem=true)