### PR TITLE
Another unhandled exception handler fix

### DIFF
--- a/Infrastructure/breakpad.cpp
+++ b/Infrastructure/breakpad.cpp
@@ -21,7 +21,7 @@ Breakpad::Breakpad(const std::wstring &crashDumpFolder)
 		MessageBox(NULL, msg.c_str(), L"TemplePlus Crashed - Oops!", MB_OK);
 
 	});
-	
+
 }
 
 Breakpad::~Breakpad()

--- a/Temple/src/dll.cpp
+++ b/Temple/src/dll.cpp
@@ -14,6 +14,10 @@
 
 #include "temple/dll.h"
 
+static void* WINAPI PreventSetUnhandledExceptionFilter(void* exc) {
+	return nullptr;
+}
+
 namespace temple {
 
 	constexpr uint32_t defaultBaseAddr = 0x10000000;
@@ -87,6 +91,7 @@ namespace temple {
 		static void DebugMessage(const char* message);
 	};
 
+
 	DllImpl::DllImpl(const std::wstring& installationDir) {
 
 		wchar_t dllPath[MAX_PATH];
@@ -128,6 +133,8 @@ namespace temple {
 			throw TempleException(msg);
 		}
 
+		void* original;
+		MH_CreateHook(SetUnhandledExceptionFilter, (void*)PreventSetUnhandledExceptionFilter, &original);
 	}
 
 	DllImpl::~DllImpl() {

--- a/TemplePlus/mainloop.cpp
+++ b/TemplePlus/mainloop.cpp
@@ -141,9 +141,6 @@ void GameLoop::Run() {
 
 	auto quit = false;
 	while (!quit) {
-
-		
-
 		// Read user input and external system events (such as time)
 		messageQueue->PollExternalEvents();			
 		if (mDiagScreen->IsEnabled()) {	


### PR DESCRIPTION
The MSS DLLs are also registering unhandled exception handlers, thus making us use these dirty hacks.