### PR TITLE
Fix Camera Issues in AdvanceTime/ProcessMessages when renderSize!=screenSize

### DIFF
--- a/Infrastructure/include/graphics/camera.h
+++ b/Infrastructure/include/graphics/camera.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "../infrastructure/location.h"
 #include "collision.h"
 #include "math.h"
@@ -12,7 +14,6 @@ namespace gfx {
 	 */
 	class WorldCamera {
 	public:
-
 		bool IsBoxOnScreen(XMFLOAT2 point, 
 			float left, float top, float right, float bottom) const;
 		
@@ -48,7 +49,10 @@ namespace gfx {
 			return mCurScreenOffset;
 		}
 
-		void SetScreenWidth(float width, float height) {
+		void SetScreenSize(float width, float height) {
+			if (std::abs(width - mScreenWidth) < 0.01f || std::abs(height - mScreenHeight) < 0.01f) {
+				return;
+			}
 			mScreenWidth = width;
 			mScreenHeight = height;
 			mDirty = true;

--- a/Infrastructure/include/graphics/camera.h
+++ b/Infrastructure/include/graphics/camera.h
@@ -102,11 +102,6 @@ namespace gfx {
 		 */
 		Ray3d GetPickRay(float x, float y);
 
-		XMFLOAT2 ScreenToTileLegacy(int x, int y);
-
-		LocAndOffsets ScreenToTile(int screenX, int screenY);
-		XMFLOAT3 TileToWorld(locXY tilePos);
-
 		void CenterOn(float x, float y, float z);
 
 		const XMFLOAT4X4 &GetUiProjection() {

--- a/Infrastructure/include/graphics/device.h
+++ b/Infrastructure/include/graphics/device.h
@@ -39,6 +39,7 @@ namespace gfx {
 	using DepthStencilStatePtr = std::shared_ptr<DepthStencilState>;
 	using BlendStatePtr = std::shared_ptr<BlendState>;
 	using RasterizerStatePtr = std::shared_ptr<RasterizerState>;
+	using WorldCameraPtr = std::shared_ptr<WorldCamera>;
 
 	using ResizeListener = std::function<void(int w, int h)>;
 
@@ -302,9 +303,17 @@ namespace gfx {
 			return mTextures;
 		}
 
-		WorldCamera& GetCamera() {
-			return mCamera;
+		/**
+		 * Returns the current camera used to render.
+		 */
+		WorldCamera &GetCurrentCamera() {
+			return *mCurrentCamera;
 		}
+
+		/**
+		 * Returns the camera that will be used for rendering.
+		 */
+		void SetCurrentCamera(WorldCameraPtr camera);
 
 		void SetAntiAliasing(bool enable, uint32_t samples, uint32_t quality);
 		
@@ -406,6 +415,8 @@ namespace gfx {
 		gsl::span<uint8_t> MapVertexBufferRaw(VertexBuffer &buffer, MapMode mode);
 		
 		CComPtr<IDXGIAdapter1> GetAdapter(size_t index);
+
+		void UpdateDefaultCameraScreenSize();
 		
 		int mBeginSceneDepth = 0;
 		
@@ -452,7 +463,8 @@ namespace gfx {
 
 		Shaders mShaders;
 		Textures mTextures;
-		WorldCamera mCamera;
+		WorldCameraPtr mDefaultCamera;
+		WorldCameraPtr mCurrentCamera;
 
 		struct Impl;
 		std::unique_ptr<Impl> mImpl;

--- a/Infrastructure/src/aas/aas_renderer.cpp
+++ b/Infrastructure/src/aas/aas_renderer.cpp
@@ -282,7 +282,7 @@ void Renderer::RenderGeometryShadow(gfx::AnimatedModel * model,
 	mDevice.SetMaterial(mGeometryShadowMaterial);
 
 	ShadowGlobals globals;
-	globals.projMatrix = mDevice.GetCamera().GetViewProj();
+	globals.projMatrix = mDevice.GetCurrentCamera().GetViewProj();
 	globals.globalLightDir = globalLight.dir;
 	globals.offsetZ = { params.offsetZ, 0, 0, 0 };
 	globals.alpha = { alpha, 0, 0, 0 };

--- a/Infrastructure/src/graphics/camera.cpp
+++ b/Infrastructure/src/graphics/camera.cpp
@@ -153,51 +153,6 @@ namespace gfx {
 		return Ray3d{ from, dir };
 	}
 
-	// TODO: See if this can just be replaced by the proper version used below
-	// This is equivalent to 10029570
-	XMFLOAT2 WorldCamera::ScreenToTileLegacy(int x, int y) {
-		
-		auto tmpX = (x - mXTranslation) * 20 / INCH_PER_TILE; // * 0.70710677
-		auto tmpY = (y - mYTranslation) / 0.7f * 20 / INCH_PER_TILE ; // * 1.0101526 originally
-
-		return {
-			tmpY - tmpX - INCH_PER_HALFTILE,
-			tmpY + tmpX - INCH_PER_HALFTILE
-		};
-
-	}
-
-	LocAndOffsets WorldCamera::ScreenToTile(int screenX, int screenY) {
-
-		auto tmpX = (int)((screenX - mXTranslation) / 2);
-		auto tmpY = (int)(((screenY - mYTranslation) / 2) / 0.7f);
-		
-		auto unrotatedX = tmpY - tmpX;
-		auto unrotatedY = tmpY + tmpX;
-		
-		// Convert to tiles
-		LocAndOffsets result;
-		result.location.locx = unrotatedX / 20;
-		result.location.locy = unrotatedY / 20;
-
-		// Convert to offset within tile
-		result.off_x = ((unrotatedX % 20) / 20.0f - 0.5f) * INCH_PER_TILE;
-		result.off_y = ((unrotatedY % 20) / 20.0f - 0.5f) * INCH_PER_TILE;
-		
-		return result;
-	}
-
-	// replaces 10028EC0
-	XMFLOAT3 WorldCamera::TileToWorld(locXY tilePos)
-	{
-		auto result = XMFLOAT3();
-		result.x = (float)((tilePos.locy - tilePos.locx - 1) * 20);
-		result.y = (float)((tilePos.locy + tilePos.locx) * 14);
-		result.z = 0;
-
-		return result;
-	}
-
 	void WorldCamera::CenterOn(float x, float y, float z) {
 
 		mDirty = true;

--- a/Infrastructure/src/graphics/camera.cpp
+++ b/Infrastructure/src/graphics/camera.cpp
@@ -191,8 +191,8 @@ namespace gfx {
 	XMFLOAT3 WorldCamera::TileToWorld(locXY tilePos)
 	{
 		auto result = XMFLOAT3();
-		result.x = (tilePos.locy - tilePos.locx - 1) * 20;
-		result.y = (tilePos.locy + tilePos.locx ) * 14;
+		result.x = (float)((tilePos.locy - tilePos.locx - 1) * 20);
+		result.y = (float)((tilePos.locy + tilePos.locx) * 14);
 		result.z = 0;
 
 		return result;

--- a/Infrastructure/src/graphics/mdfmaterials.cpp
+++ b/Infrastructure/src/graphics/mdfmaterials.cpp
@@ -99,9 +99,9 @@ namespace gfx {
 
 		XMMATRIX viewProj;
 		if (overrides && overrides->uiProjection) {
-			viewProj = XMLoadFloat4x4(&device.GetCamera().GetUiProjection());
+			viewProj = XMLoadFloat4x4(&device.GetCurrentCamera().GetUiProjection());
 		} else {
-			viewProj = XMLoadFloat4x4(&device.GetCamera().GetViewProj());
+			viewProj = XMLoadFloat4x4(&device.GetCurrentCamera().GetViewProj());
 		}
 
 		// Should we use a separate world matrix?

--- a/Infrastructure/src/graphics/shaperenderer2d.cpp
+++ b/Infrastructure/src/graphics/shaperenderer2d.cpp
@@ -447,7 +447,7 @@ void ShapeRenderer2d::DrawRectangleOutline(XMFLOAT2 topLeft, XMFLOAT2 bottomRigh
 		bufferBinding.Bind();
 
 		PieSegmentGlobals globals;
-		globals.projMat = device.GetCamera().GetUiProjection();
+		globals.projMat = device.GetCurrentCamera().GetUiProjection();
 		XMStoreFloat4(&globals.colors, PackedVector::XMLoadColor(&color1));
 		device.SetVertexShaderConstants(0, globals);
 

--- a/Infrastructure/src/graphics/shaperenderer3d.cpp
+++ b/Infrastructure/src/graphics/shaperenderer3d.cpp
@@ -193,7 +193,7 @@ namespace gfx {
 		}
 
 		Shape3dGlobals globals;
-		globals.viewProj = device.GetCamera().GetViewProj();
+		globals.viewProj = device.GetCurrentCamera().GetViewProj();
 		XMStoreFloat4(&globals.colors, PackedVector::XMLoadColor(&color));
 		
 		device.SetVertexShaderConstants(0, globals);
@@ -204,7 +204,7 @@ namespace gfx {
 		device.SetMaterial(quadMaterial);
 
 		Shape3dGlobals globals;
-		globals.viewProj = device.GetCamera().GetViewProj();
+		globals.viewProj = device.GetCurrentCamera().GetViewProj();
 		XMStoreFloat4(&globals.colors, PackedVector::XMLoadColor(&color));
 
 		device.SetVertexShaderConstants(0, globals);

--- a/ParticleSystems/include/particles/render.h
+++ b/ParticleSystems/include/particles/render.h
@@ -31,9 +31,9 @@ namespace particles {
 		These vectors can be multiplied with screen space
 		coordinates to get world coordinates.
 		*/
-		XMFLOAT4 screenSpaceUnitX;
-		XMFLOAT4 screenSpaceUnitY;
-		XMFLOAT4 screenSpaceUnitZ;
+		XMFLOAT4 screenSpaceUnitX{};
+		XMFLOAT4 screenSpaceUnitY{};
+		XMFLOAT4 screenSpaceUnitZ{};
 
 		NO_COPY_OR_MOVE(ParticleRenderer);
 	private:

--- a/ParticleSystems/src/render.cpp
+++ b/ParticleSystems/src/render.cpp
@@ -79,7 +79,7 @@ namespace particles {
 
 				XMStoreFloat4x4(
 					&worldMatrix,
-					localMat * XMLoadFloat4x4(&mDevice.GetCamera().GetViewProj())
+					localMat * XMLoadFloat4x4(&mDevice.GetCurrentCamera().GetViewProj())
 				);
 				ExtractScreenSpaceUnitVectors(worldMatrix);
 				return true;
@@ -102,7 +102,7 @@ namespace particles {
 
 					XMStoreFloat4x4(
 						&worldMatrix,
-						XMLoadFloat4x4(&boneMatrix) * XMLoadFloat4x4(&mDevice.GetCamera().GetViewProj())
+						XMLoadFloat4x4(&boneMatrix) * XMLoadFloat4x4(&mDevice.GetCurrentCamera().GetViewProj())
 						);
 					ExtractScreenSpaceUnitVectors(worldMatrix);
 					return true;
@@ -116,7 +116,7 @@ namespace particles {
 
 					XMStoreFloat4x4(
 						&worldMatrix,
-						XMMatrixTranslation(x, y, z) * XMLoadFloat4x4(&mDevice.GetCamera().GetViewProj())
+						XMMatrixTranslation(x, y, z) * XMLoadFloat4x4(&mDevice.GetCurrentCamera().GetViewProj())
 						);
 
 					ExtractScreenSpaceUnitVectors(worldMatrix);
@@ -126,13 +126,13 @@ namespace particles {
 				return false;
 			}
 
-			worldMatrix = mDevice.GetCamera().GetViewProj();
+			worldMatrix = mDevice.GetCurrentCamera().GetViewProj();
 			ExtractScreenSpaceUnitVectors(worldMatrix);
 			return true;
 		}
 
 		if (particleSpace == PartSysParticleSpace::World) {
-			worldMatrix = mDevice.GetCamera().GetViewProj();
+			worldMatrix = mDevice.GetCurrentCamera().GetViewProj();
 			ExtractScreenSpaceUnitVectors(worldMatrix);
 			return true;
 		}
@@ -158,7 +158,7 @@ namespace particles {
 						boneMatrix._43)
 					); // TODO: This might not be needed...
 			}
-			worldMatrix = mDevice.GetCamera().GetViewProj();
+			worldMatrix = mDevice.GetCurrentCamera().GetViewProj();
 			ExtractScreenSpaceUnitVectors2(boneMatrix);
 			return true;
 		}
@@ -170,7 +170,7 @@ namespace particles {
 		} else {
 			XMStoreFloat4x4(&matrix, XMMatrixIdentity());
 		}
-		worldMatrix = mDevice.GetCamera().GetViewProj();
+		worldMatrix = mDevice.GetCurrentCamera().GetViewProj();
 		ExtractScreenSpaceUnitVectors2(matrix);
 		return true;
 	}

--- a/TemplePlus/animgoals/animgoals_debugrenderer.cpp
+++ b/TemplePlus/animgoals/animgoals_debugrenderer.cpp
@@ -3,6 +3,7 @@
 
 #include "animgoals_debugrenderer.h"
 #include "party.h"
+#include "gameview.h"
 
 #include <tig/tig_startup.h>
 #include <graphics/device.h>
@@ -67,7 +68,7 @@ void AnimGoalsDebugRenderer::RenderAnimGoals(objHndl handle)
 
 	auto worldLocAboveHead = objects.GetLocationFull(handle).ToInches3D(objects.GetRenderHeight(handle));
 
-	auto topOfObjectInUi = tig->GetRenderingDevice().GetCamera().WorldToScreenUi(worldLocAboveHead);
+	auto topOfObjectInUi = gameView->GetCamera().WorldToScreenUi(worldLocAboveHead);
 
 	auto &renderer2d = tig->GetShapeRenderer2d();
 

--- a/TemplePlus/animgoals/animgoals_debugrenderer.cpp
+++ b/TemplePlus/animgoals/animgoals_debugrenderer.cpp
@@ -68,7 +68,7 @@ void AnimGoalsDebugRenderer::RenderAnimGoals(objHndl handle)
 
 	auto worldLocAboveHead = objects.GetLocationFull(handle).ToInches3D(objects.GetRenderHeight(handle));
 
-	auto topOfObjectInUi = gameView->GetCamera().WorldToScreenUi(worldLocAboveHead);
+	auto topOfObjectInUi = gameView->WorldToScreenUi(worldLocAboveHead);
 
 	auto &renderer2d = tig->GetShapeRenderer2d();
 

--- a/TemplePlus/gamesystems/clipping/clipping.cpp
+++ b/TemplePlus/gamesystems/clipping/clipping.cpp
@@ -16,11 +16,21 @@ using namespace gfx;
 
 class ClippingSystem::Impl {
 public:
-	explicit Impl(RenderingDevice& g);
+	explicit Impl(RenderingDevice& g, WorldCamera& camera) : 
+		device(g),
+		camera(camera),
+		material(CreateMaterial(g)),
+		debugMaterial(CreateDebugMaterial(g)),
+		mBufferBinding(material.GetVertexShader())
+	{
+		mBufferBinding.AddBuffer(nullptr, 0, sizeof(XMFLOAT3))
+			.AddElement(VertexElementType::Float3, VertexElementSemantic::Position);
+	}
 
 	std::vector<std::unique_ptr<ClippingMesh>> mClippingMeshes;
 
-	RenderingDevice& mDevice;
+	RenderingDevice& device;
+	WorldCamera& camera;
 	Material material;
 	Material debugMaterial;
 	BufferBinding mBufferBinding;
@@ -30,18 +40,6 @@ public:
 	static Material CreateMaterial(RenderingDevice &device);
 	static Material CreateDebugMaterial(RenderingDevice &device);
 };
-
-ClippingSystem::Impl::Impl(RenderingDevice& g) 
-	: mDevice(g), 
-	  material(CreateMaterial(g)),
-	  debugMaterial(CreateDebugMaterial(g)),
-	  mBufferBinding(material.GetVertexShader())
-{
-
-	mBufferBinding.AddBuffer(nullptr, 0, sizeof(XMFLOAT3))
-		.AddElement(VertexElementType::Float3, VertexElementSemantic::Position);
-
-}
 
 Material ClippingSystem::Impl::CreateMaterial(RenderingDevice& device) {
 	RasterizerSpec rasterizerState;
@@ -73,7 +71,8 @@ Material ClippingSystem::Impl::CreateDebugMaterial(RenderingDevice& device) {
 
 }
 
-ClippingSystem::ClippingSystem(RenderingDevice& g) : mImpl(std::make_unique<Impl>(g)) {
+ClippingSystem::ClippingSystem(RenderingDevice& g, WorldCamera &camera) 
+	: mImpl(std::make_unique<Impl>(g, camera)) {
 }
 
 ClippingSystem::~ClippingSystem() {
@@ -142,7 +141,7 @@ void ClippingSystem::LoadMeshes(const std::string& directory) {
 
 		try {
 			mImpl->mClippingMeshes.emplace_back(
-				std::make_unique<ClippingMesh>(mImpl->mDevice, meshFilename)
+				std::make_unique<ClippingMesh>(mImpl->device, meshFilename)
 			);
 		} catch (TempleException &e) {
 			logger->error("Failed to load clipping mesh {}: {}", filename, e.what());
@@ -199,7 +198,7 @@ struct ClippingGlobals {
 
 void ClippingSystem::Render() {
 
-	gfx::PerfGroup perfGroup(mImpl->mDevice, "Clipping");
+	gfx::PerfGroup perfGroup(mImpl->device, "Clipping");
 
 	mImpl->rendered = 0;
 
@@ -208,12 +207,12 @@ void ClippingSystem::Render() {
 	}
 	
 	if (mImpl->debug) {
-		mImpl->mDevice.SetMaterial(mImpl->debugMaterial);
+		mImpl->device.SetMaterial(mImpl->debugMaterial);
 	} else {
-		mImpl->mDevice.SetMaterial(mImpl->material);
+		mImpl->device.SetMaterial(mImpl->material);
 	}
 
-	auto& camera = gameView->GetCamera();
+	auto& camera = mImpl->camera;
 
 	ClippingGlobals globals;
 	globals.viewProj = camera.GetViewProj();
@@ -229,7 +228,7 @@ void ClippingSystem::Render() {
 	
 		mImpl->mBufferBinding.SetBuffer(0, mesh->GetVertexBuffer());
 		mImpl->mBufferBinding.Bind();
-		mImpl->mDevice.SetIndexBuffer(*mesh->GetIndexBuffer());
+		mImpl->device.SetIndexBuffer(*mesh->GetIndexBuffer());
 		
 		for (auto& obj : mesh->GetInstances()) {
 			XMFLOAT3 sphereCenter = mesh->GetBoundingSphereOrigin();
@@ -264,9 +263,9 @@ void ClippingSystem::Render() {
 			globals.scale.y = obj.scaleY;
 			globals.scale.z = obj.scaleZ;
 			
-			mImpl->mDevice.SetVertexShaderConstants(0, globals);
+			mImpl->device.SetVertexShaderConstants(0, globals);
 
-			mImpl->mDevice.DrawIndexed(
+			mImpl->device.DrawIndexed(
 				gfx::PrimitiveType::TriangleList,
 				mesh->GetVertexCount(),
 				mesh->GetTriCount() * 3

--- a/TemplePlus/gamesystems/clipping/clipping.cpp
+++ b/TemplePlus/gamesystems/clipping/clipping.cpp
@@ -9,7 +9,7 @@
 #include "clipping.h"
 #include "graphics/shaders.h"
 #include "clippingmesh.h"
-
+#include "../../gameview.h"
 #include "config/config.h"
 
 using namespace gfx;
@@ -213,16 +213,13 @@ void ClippingSystem::Render() {
 		mImpl->mDevice.SetMaterial(mImpl->material);
 	}
 
-	auto& camera = mImpl->mDevice.GetCamera();
+	auto& camera = gameView->GetCamera();
 
 	ClippingGlobals globals;
 	globals.viewProj = camera.GetViewProj();
 
 	// For clipping purposes
-	auto screenCenterWorld = camera.ScreenToWorld(
-		camera.GetScreenWidth() * 0.5f, 
-		camera.GetScreenHeight() * 0.5f
-	);
+	auto screenCenterWorld = gameView->GetScreenCenterInWorld3d();
 
 	for (auto& mesh : mImpl->mClippingMeshes) {
 				

--- a/TemplePlus/gamesystems/clipping/clipping.h
+++ b/TemplePlus/gamesystems/clipping/clipping.h
@@ -4,6 +4,7 @@
 
 namespace gfx {
 	class RenderingDevice;
+	class WorldCamera;
 }
 
 class BinaryReader;
@@ -12,7 +13,7 @@ class ClippingSystem : public GameSystem {
 public:	
 	static constexpr auto Name = "Clipping";
 
-	explicit ClippingSystem(gfx::RenderingDevice& g);
+	explicit ClippingSystem(gfx::RenderingDevice& g, gfx::WorldCamera& camera);
 	~ClippingSystem();
 
 	void Load(const std::string& directory);

--- a/TemplePlus/gamesystems/gamerenderer.cpp
+++ b/TemplePlus/gamesystems/gamerenderer.cpp
@@ -132,8 +132,10 @@ static struct GameRenderFuncs : temple::AddressTable {
 } renderFuncs;
 
 GameRenderer::GameRenderer(TigInitializer &tig,
+                           WorldCamera &camera,
                            GameSystems &gameSystems)
     : mRenderingDevice(tig.GetRenderingDevice()), 
+      mCamera(camera),
 	  mGameSystems(gameSystems)      
 {
 
@@ -152,6 +154,7 @@ GameRenderer::GameRenderer(TigInitializer &tig,
 		*mAasRenderer);
 	mParticleSysRenderer = std::make_unique<ParticleSystemsRenderer>(
 		tig.GetRenderingDevice(),
+        mCamera,
 		tig.GetShapeRenderer2d(),
 		gameSystems.GetAAS(),
 		*mAasRenderer,

--- a/TemplePlus/gamesystems/gamerenderer.cpp
+++ b/TemplePlus/gamesystems/gamerenderer.cpp
@@ -150,6 +150,7 @@ GameRenderer::GameRenderer(TigInitializer &tig,
 	mMapObjectRenderer = std::make_unique<MapObjectRenderer>(
 		gameSystems, 
 		tig.GetRenderingDevice(), 
+        camera,
 		tig.GetMdfFactory(),
 		*mAasRenderer);
 	mParticleSysRenderer = std::make_unique<ParticleSystemsRenderer>(

--- a/TemplePlus/gamesystems/gamerenderer.h
+++ b/TemplePlus/gamesystems/gamerenderer.h
@@ -4,6 +4,7 @@
 class TigInitializer;
 namespace gfx {
 	class RenderingDevice;
+	class WorldCamera;
 }
 namespace aas {
 	class Renderer;
@@ -26,7 +27,7 @@ class TileRenderer;
 
 class GameRenderer {
 public:
-	GameRenderer(TigInitializer &tig, GameSystems &gameSystems);
+	GameRenderer(TigInitializer &tig, gfx::WorldCamera &camera, GameSystems &gameSystems);
 	~GameRenderer();
 
 	void Render();
@@ -44,6 +45,7 @@ private:
 	void RenderWorld(RenderWorldInfo *info);
 	
 	gfx::RenderingDevice& mRenderingDevice;
+	gfx::WorldCamera& mCamera;
 	GameSystems &mGameSystems;
 
 	std::unique_ptr<aas::Renderer> mAasRenderer;

--- a/TemplePlus/gamesystems/gamesystems.cpp
+++ b/TemplePlus/gamesystems/gamesystems.cpp
@@ -688,7 +688,7 @@ void GameSystems::InitializeSystems(LoadingScreen& loadingScreen) {
 	loadingScreen.SetProgress(31 / 79.0f);
 	mJumpPoint = InitializeSystem<JumpPointSystem>(loadingScreen);
 	loadingScreen.SetProgress(32 / 79.0f);
-	mClipping = InitializeSystem<ClippingSystem>(loadingScreen, mTig.GetRenderingDevice());
+	mClipping = InitializeSystem<ClippingSystem>(loadingScreen, mTig.GetRenderingDevice(), *mTig.GetGameView().GetCamera());
 	mTerrain = InitializeSystem<TerrainSystem>(loadingScreen, mTig.GetRenderingDevice(),
 		mTig.GetShapeRenderer2d());
 	loadingScreen.SetProgress(33 / 79.0f);
@@ -771,7 +771,7 @@ void GameSystems::InitializeSystems(LoadingScreen& loadingScreen) {
 	loadingScreen.SetProgress(69 / 79.0f);
 	mUiArtManager = InitializeSystem<UiArtManagerSystem>(loadingScreen, mConfig);
 	loadingScreen.SetProgress(70 / 79.0f);
-	mParticleSys = InitializeSystem<ParticleSysSystem>(loadingScreen, gameView->GetCamera());
+	mParticleSys = InitializeSystem<ParticleSysSystem>(loadingScreen, *gameView->GetCamera());
 	loadingScreen.SetProgress(71 / 79.0f);
 	mCheats = InitializeSystem<CheatsSystem>(loadingScreen, mConfig);
 	loadingScreen.SetProgress(72 / 79.0f);

--- a/TemplePlus/gamesystems/gamesystems.cpp
+++ b/TemplePlus/gamesystems/gamesystems.cpp
@@ -28,6 +28,7 @@
 #include "gamesystems/objfade.h"
 #include "gamesystems/objects/objsystem.h"
 #include "gamesystems/map/gmesh.h"
+#include "../gameview.h"
 #include "animgoals/anim.h"
 
 #include "mapsystem.h"
@@ -770,8 +771,7 @@ void GameSystems::InitializeSystems(LoadingScreen& loadingScreen) {
 	loadingScreen.SetProgress(69 / 79.0f);
 	mUiArtManager = InitializeSystem<UiArtManagerSystem>(loadingScreen, mConfig);
 	loadingScreen.SetProgress(70 / 79.0f);
-	mParticleSys = InitializeSystem<ParticleSysSystem>(loadingScreen, 
-		mTig.GetRenderingDevice().GetCamera());
+	mParticleSys = InitializeSystem<ParticleSysSystem>(loadingScreen, gameView->GetCamera());
 	loadingScreen.SetProgress(71 / 79.0f);
 	mCheats = InitializeSystem<CheatsSystem>(loadingScreen, mConfig);
 	loadingScreen.SetProgress(72 / 79.0f);

--- a/TemplePlus/gamesystems/legacysystems.cpp
+++ b/TemplePlus/gamesystems/legacysystems.cpp
@@ -30,6 +30,7 @@
 #include "turn_based.h"
 #include "d20_race.h"
 #include "ai.h"
+#include "gameview.h"
 #include <hotkeys.h>
 
 
@@ -1929,10 +1930,11 @@ void MapFoggingSystem::InitScreenBuffers() {
 	mScreenHeight = config.renderHeight;
 
 	// Calculate the tile locations in each corner of the screen
-	auto topLeftLoc = mDevice.GetCamera().ScreenToTile(0, 0);
-	auto topRightLoc = mDevice.GetCamera().ScreenToTile(mScreenWidth, 0);
-	auto bottomLeftLoc = mDevice.GetCamera().ScreenToTile(0, mScreenHeight);
-	auto bottomRightLoc = mDevice.GetCamera().ScreenToTile(mScreenWidth, mScreenHeight);
+	auto& camera = gameView->GetCamera();
+	auto topLeftLoc = camera.ScreenToTile(0, 0);
+	auto topRightLoc = camera.ScreenToTile(mScreenWidth, 0);
+	auto bottomLeftLoc = camera.ScreenToTile(0, mScreenHeight);
+	auto bottomRightLoc = camera.ScreenToTile(mScreenWidth, mScreenHeight);
 
 	mFogMinX = topRightLoc.location.locx;
 	mFogMinY = topLeftLoc.location.locy;

--- a/TemplePlus/gamesystems/legacysystems.cpp
+++ b/TemplePlus/gamesystems/legacysystems.cpp
@@ -1930,11 +1930,10 @@ void MapFoggingSystem::InitScreenBuffers() {
 	mScreenHeight = config.renderHeight;
 
 	// Calculate the tile locations in each corner of the screen
-	auto& camera = gameView->GetCamera();
-	auto topLeftLoc = camera.ScreenToTile(0, 0);
-	auto topRightLoc = camera.ScreenToTile(mScreenWidth, 0);
-	auto bottomLeftLoc = camera.ScreenToTile(0, mScreenHeight);
-	auto bottomRightLoc = camera.ScreenToTile(mScreenWidth, mScreenHeight);
+	auto topLeftLoc = gameView->ScreenToTile(0, 0);
+	auto topRightLoc = gameView->ScreenToTile(mScreenWidth, 0);
+	auto bottomLeftLoc = gameView->ScreenToTile(0, mScreenHeight);
+	auto bottomRightLoc = gameView->ScreenToTile(mScreenWidth, mScreenHeight);
 
 	mFogMinX = topRightLoc.location.locx;
 	mFogMinY = topLeftLoc.location.locy;

--- a/TemplePlus/gamesystems/mapobjrender.cpp
+++ b/TemplePlus/gamesystems/mapobjrender.cpp
@@ -14,6 +14,7 @@
 #include <graphics/shaperenderer2d.h>
 #include <aas/aas_renderer.h>
 #include "../critter.h"
+#include "gameview.h"
 #include <graphics/dynamictexture.h>
 
 #include "froggrapplecontroller.h"
@@ -344,7 +345,7 @@ void MapObjectRenderer::RenderObject(objHndl handle, bool showInvisible) {
 void MapObjectRenderer::RenderObjectInUi(objHndl handle, int x, int y, float rotation, float scale) {
 
 	// The y-15 is a hack to get it to be centered, in reality this would really need a rewrite of the entire camera system :-|
-	auto worldPos = mDevice.GetCamera().ScreenToWorld((float)x, (float)y - 15);
+	auto worldPos = gameView->GetCamera().ScreenToWorld((float)x, (float)y - 15);
 
 	auto animatedModel = objects.GetAnimHandle(handle);
 
@@ -884,7 +885,7 @@ bool MapObjectRenderer::IsObjectOnScreen(LocAndOffsets &location, float offsetZ,
 {
 
 	auto centerOfTile3d = location.ToInches3D();
-	auto screenPos = mDevice.GetCamera().WorldToScreenUi(centerOfTile3d);
+	auto screenPos = gameView->GetCamera().WorldToScreenUi(centerOfTile3d);
 
 	// This checks if the object's screen bounding box is off screen
 	auto bbLeft = screenPos.x - radius;
@@ -892,8 +893,8 @@ bool MapObjectRenderer::IsObjectOnScreen(LocAndOffsets &location, float offsetZ,
 	auto bbTop = screenPos.y - (offsetZ + renderHeight + radius) * cos45;
 	auto bbBottom = bbTop + (2 * radius + renderHeight) * cos45;
 
-	auto screenWidth = mDevice.GetCamera().GetScreenWidth();
-	auto screenHeight = mDevice.GetCamera().GetScreenHeight();
+	auto screenWidth = gameView->GetCamera().GetScreenWidth();
+	auto screenHeight = gameView->GetCamera().GetScreenHeight();
 	if (bbRight < 0 || bbBottom < 0 || bbLeft > screenWidth || bbTop > screenHeight) {
 		return false;
 	}
@@ -1067,7 +1068,7 @@ public:
 
 			// Char creation makes assumption about the main menu which no longer hold, so we
 			// manually restore the 1x scale of the normal world before we render
-			auto &camera = tig->GetRenderingDevice().GetCamera();
+			auto &camera = gameView->GetCamera();
 			auto orgScale = camera.GetScale();
 			camera.SetScale(1.0f);
 			if (charGen) {

--- a/TemplePlus/gamesystems/mapobjrender.h
+++ b/TemplePlus/gamesystems/mapobjrender.h
@@ -5,6 +5,7 @@
 namespace gfx {
 	struct AnimatedModelParams;
 	class RenderingDevice;
+	class WorldCamera;
 	struct Light3d;
 	class AnimatedModel;
 	class MdfMaterialFactory;
@@ -28,6 +29,7 @@ public:
 
 	MapObjectRenderer(GameSystems& gameSystems, 
 		gfx::RenderingDevice& device, 
+		gfx::WorldCamera& camera,
 		gfx::MdfMaterialFactory &mdfFactory,
 		aas::Renderer &aasRenderer);
 	~MapObjectRenderer();
@@ -66,6 +68,7 @@ public:
 private:
 	GameSystems& mGameSystems;
 	gfx::RenderingDevice& mDevice;
+	gfx::WorldCamera& mCamera;
 	aas::Renderer &mAasRenderer;
 	ShadowType mShadowType = ShadowType::ShadowMap;
 	gfx::MdfRenderMaterialPtr mBlobShadowMaterial;

--- a/TemplePlus/gamesystems/partsystemsrenderer.cpp
+++ b/TemplePlus/gamesystems/partsystemsrenderer.cpp
@@ -19,11 +19,13 @@ using namespace particles;
 
 ParticleSystemsRenderer::ParticleSystemsRenderer(
 	RenderingDevice &renderingDevice,
+	WorldCamera &camera,
 	ShapeRenderer2d &shapeRenderer2d,
 	AnimatedModelFactory &modelFactory,
 	AnimatedModelRenderer &modelRenderer,
 	ParticleSysSystem &particleSysSystem
 	) : mRenderingDevice(renderingDevice), 
+		mCamera(camera),
 		mShapeRenderer2d(shapeRenderer2d),		
 		mParticleSysSystem(particleSysSystem) {
 
@@ -44,8 +46,6 @@ void ParticleSystemsRenderer::Render()
 
 	gfx::PerfGroup perfGroup(mRenderingDevice, "Particles");
 
-	auto& camera = mRenderingDevice.GetCamera();
-
 	mTotalLastFrame = 0;
 	mRenderedLastFrame = 0;
 
@@ -58,7 +58,7 @@ void ParticleSystemsRenderer::Render()
 
 		auto screenBounds(partSys.GetScreenBounds());
 
-		if (!camera.IsBoxOnScreen(partSys.GetScreenPosAbs(),
+		if (!mCamera.IsBoxOnScreen(partSys.GetScreenPosAbs(),
 			screenBounds.left, screenBounds.top,
 			screenBounds.right, screenBounds.bottom)) {
 			continue;
@@ -96,20 +96,18 @@ void ParticleSystemsRenderer::Render()
 
 void ParticleSystemsRenderer::RenderDebugInfo(const particles::PartSys &sys)
 {
-	auto& camera = mRenderingDevice.GetCamera();
-
-	auto dx = camera.Get2dTranslation().x;
-	auto dy = camera.Get2dTranslation().y;
+	auto dx = mCamera.Get2dTranslation().x;
+	auto dy = mCamera.Get2dTranslation().y;
 
 	auto screenX = dx - sys.GetScreenPosAbs().x;
 	auto screenY = dy - sys.GetScreenPosAbs().y;
 	auto screenBounds(sys.GetScreenBounds());
 
-	screenX *= camera.GetScale();
-	screenY *= camera.GetScale();
+	screenX *= mCamera.GetScale();
+	screenY *= mCamera.GetScale();
 
-	screenX += camera.GetScreenWidth() * 0.5f;
-	screenY += camera.GetScreenHeight() * 0.5f;
+	screenX += mCamera.GetScreenWidth() * 0.5f;
+	screenY += mCamera.GetScreenHeight() * 0.5f;
 
 	float left = { screenX + screenBounds.left };
 	float top = { screenY + screenBounds.top };

--- a/TemplePlus/gamesystems/partsystemsrenderer.h
+++ b/TemplePlus/gamesystems/partsystemsrenderer.h
@@ -6,6 +6,7 @@ namespace gfx {
 	class ShapeRenderer2d;
 	class AnimatedModelFactory;
 	class AnimatedModelRenderer;
+	class WorldCamera;
 }
 namespace particles {
 	class ParticleRendererManager;
@@ -18,6 +19,7 @@ class ParticleSystemsRenderer {
 public:
 	ParticleSystemsRenderer(
 		gfx::RenderingDevice &mRenderingDevice,
+		gfx::WorldCamera &mCamera,
 		gfx::ShapeRenderer2d &mShapeRenderer2d,
 		gfx::AnimatedModelFactory &modelFactory,
 		gfx::AnimatedModelRenderer &modelRenderer,
@@ -42,6 +44,7 @@ public:
 
 private:
 	gfx::RenderingDevice &mRenderingDevice;
+	gfx::WorldCamera &mCamera;
 	gfx::ShapeRenderer2d &mShapeRenderer2d;
 	ParticleSysSystem &mParticleSysSystem;
 

--- a/TemplePlus/gameview.cpp
+++ b/TemplePlus/gameview.cpp
@@ -8,10 +8,13 @@
 GameView::GameView(MainWindow &mainWindow, gfx::RenderingDevice &device, int width, int height)
     : mMainWindow(mainWindow), mDevice(device), mWidth(width), mHeight(height),
       mResizeListener(device.AddResizeListener(
-          [this](int w, int h) { this->Resize(w, h); })) {
+          [this](int w, int h) { this->Resize(w, h); })),
+
+	mCamera(std::make_shared<gfx::WorldCamera>()) {
+	mCamera->SetScreenSize((float) width, (float) height);
 	
-	auto &camera = device.GetCamera();
-	Resize((int) camera.GetScreenWidth(), (int) camera.GetScreenHeight());
+	auto &backBufferSize = device.GetBackBufferSize();
+	Resize(backBufferSize.width, backBufferSize.height);
 
 	mainWindow.SetMouseMoveHandler([this](int x, int y, int wheelDelta) {
 		// Map to game view
@@ -90,6 +93,15 @@ XMINT2 GameView::MapFromScene(int x, int y) const{
 	localY += mSceneRect.y+1;
 
 	return{ (int)localX, (int)localY };
+}
+
+XMFLOAT3 GameView::GetScreenCenterInWorld3d()
+{
+	auto& camera = GetCamera();
+	return camera.ScreenToWorld(
+		camera.GetScreenWidth() * 0.5f,
+		camera.GetScreenHeight() * 0.5f
+	);
 }
 
 void GameView::Resize(int width, int height)

--- a/TemplePlus/gameview.h
+++ b/TemplePlus/gameview.h
@@ -30,10 +30,25 @@ public:
 	 */
 	XMINT2 MapFromScene(int x, int y) const;
 
+	/*
+	 * returns the camera used to render the scene
+	 */
+	gfx::WorldCamera& GetCamera() {
+		return *mCamera;
+	}
+
+	/**
+	 * Gets the world coordinate that is at the center of the screen.
+	 */
+	XMFLOAT3 GetScreenCenterInWorld3d();
+
 private:
+	friend class GameLoop;
+
 	gfx::ResizeListenerRegistration mResizeListener;
 	MainWindow &mMainWindow;
 	gfx::RenderingDevice &mDevice;
+	gfx::WorldCameraPtr mCamera;
 	int mWidth;
 	int mHeight;
 	float mSceneScale;

--- a/TemplePlus/gameview.h
+++ b/TemplePlus/gameview.h
@@ -15,9 +15,23 @@ public:
 	int GetHeight() const {
 		return mHeight;
 	}
+	float GetZoom() const {
+		return mCamera->GetScale();
+	}
+	void SetZoom(float zoom) const {
+		mCamera->SetScale(zoom);
+	}
 
 	XMFLOAT4 GetSceneRect() const {
 		return mSceneRect;
+	}
+
+	void SetTranslation(float x, float y) {
+		mCamera->SetTranslation(x, y);
+	}
+
+	XMFLOAT2 GetTranslation() const {
+		return mCamera->GetTranslation();
 	}
 
 	/**
@@ -33,14 +47,32 @@ public:
 	/*
 	 * returns the camera used to render the scene
 	 */
-	gfx::WorldCamera& GetCamera() {
-		return *mCamera;
+	const gfx::WorldCameraPtr &GetCamera() {
+		return mCamera;
 	}
 
 	/**
 	 * Gets the world coordinate that is at the center of the screen.
 	 */
 	XMFLOAT3 GetScreenCenterInWorld3d();
+
+	XMFLOAT3 ScreenToWorld(float x, float y) {
+		return mCamera->ScreenToWorld(x, y);
+	}
+
+	XMFLOAT2 WorldToScreenUi(XMFLOAT3 worldPos) {
+		return mCamera->WorldToScreenUi(worldPos);
+	}
+
+	Ray3d GetPickRay(float x, float y) {
+		return mCamera->GetPickRay(x, y);
+	}
+
+	XMFLOAT3 TileToWorld(locXY tilePos);
+
+	LocAndOffsets ScreenToTile(int screenX, int screenY);
+
+	XMFLOAT2 ScreenToTileLegacy(int x, int y);
 
 private:
 	friend class GameLoop;

--- a/TemplePlus/graphics/loadingscreen.cpp
+++ b/TemplePlus/graphics/loadingscreen.cpp
@@ -43,8 +43,8 @@ struct LoadingScreen::Impl {
 
 void LoadingScreen::Impl::Layout() {
 	
-	auto centerX = device.GetCamera().GetScreenWidth() / 2.0f;
-	auto centerY = device.GetCamera().GetScreenHeight() / 2.0f;
+	auto centerX = device.GetCurrentCamera().GetScreenWidth() / 2.0f;
+	auto centerY = device.GetCurrentCamera().GetScreenHeight() / 2.0f;
 
 	auto imgX = (int)(centerX - imageFile->GetWidth() / 2.0f);
 	auto imgY = (int)(centerY - imageFile->GetHeight() / 2.0f);

--- a/TemplePlus/graphics/video_hooks.cpp
+++ b/TemplePlus/graphics/video_hooks.cpp
@@ -263,10 +263,10 @@ void VideoFixes::UpdateProjMatrices(const TigMatrices& matrices) {
 
 	auto& device = tig->GetRenderingDevice();
 
-	gameView->GetCamera().SetTranslation(transX, transY);
-	gameView->GetCamera().SetScale(matrices.scale);
+	gameView->SetTranslation(transX, transY);
+	gameView->SetZoom(matrices.scale);
 
-	auto viewProjNew(gameView->GetCamera().GetViewProj());
+	auto viewProjNew(gameView->GetCamera()->GetViewProj());
 	auto viewProjOld(temple::GetRef<XMFLOAT4X4>(0x11E75788));
 	XMFLOAT4X4 diff;
 	XMStoreFloat4x4(&diff, XMLoadFloat4x4(&viewProjNew) - XMLoadFloat4x4(&viewProjOld));

--- a/TemplePlus/graphics/video_hooks.cpp
+++ b/TemplePlus/graphics/video_hooks.cpp
@@ -15,6 +15,7 @@
 #include "config/config.h"
 #include "util/fixes.h"
 #include "mainwindow.h"
+#include "../gameview.h"
 #include <tig/tig_startup.h>
 
 #include "legacyvideosystem.h"
@@ -262,10 +263,10 @@ void VideoFixes::UpdateProjMatrices(const TigMatrices& matrices) {
 
 	auto& device = tig->GetRenderingDevice();
 
-	device.GetCamera().SetTranslation(transX, transY);
-	device.GetCamera().SetScale(matrices.scale);
+	gameView->GetCamera().SetTranslation(transX, transY);
+	gameView->GetCamera().SetScale(matrices.scale);
 
-	auto viewProjNew(tig->GetRenderingDevice().GetCamera().GetViewProj());
+	auto viewProjNew(gameView->GetCamera().GetViewProj());
 	auto viewProjOld(temple::GetRef<XMFLOAT4X4>(0x11E75788));
 	XMFLOAT4X4 diff;
 	XMStoreFloat4x4(&diff, XMLoadFloat4x4(&viewProjNew) - XMLoadFloat4x4(&viewProjOld));

--- a/TemplePlus/mainloop.cpp
+++ b/TemplePlus/mainloop.cpp
@@ -99,7 +99,7 @@ GameLoop::GameLoop(TigInitializer& tig, GameSystems& gameSystems, Updater &updat
 	: mTig(tig),
 	  mGameSystems(gameSystems),
 	  mUpdater(updater),
-	  mGameRenderer(tig, gameView->GetCamera(), mGameSystems) {
+	  mGameRenderer(tig, *gameView->GetCamera(), mGameSystems) {
 
 	mDiagScreen = std::make_unique<DiagScreen>(tig.GetRenderingDevice(),
 		gameSystems,
@@ -126,17 +126,16 @@ GameLoop::~GameLoop() {
 	temple_main, there is no need to hook this function in temple.dll
 */
 void GameLoop::Run() {
-	auto& camera = gameView->GetCamera();
+	auto& gameView = mTig.GetGameView();
+
 	// Is this a center map kind of deal?
-	auto worldPos = camera.ScreenToWorld(400, 300);
+	auto worldPos = gameView.ScreenToWorld(400, 300);
 	locXY loc{ (uint32_t)(worldPos.x / INCH_PER_TILE), (uint32_t)(worldPos.z / INCH_PER_TILE) };
 	mainLoop.sub_1002A580(loc);
 
 	mainLoop.QueueFidgetAnimEvent();
 
 	TigMsg msg;
-
-	auto& gameView = mTig.GetGameView();
 
 	auto quit = false;
 	while (!quit) {
@@ -260,7 +259,7 @@ void GameLoop::RenderFrame() {
 	mouseFuncs.InvokeCursorDrawCallback();
 	mouseFuncs.DrawItemUnderCursor(); // This draws dragged items
 
-	// Reset the render target
+	// Reset the render target and camera
 	device.PopRenderTarget();
 	device.SetCurrentCamera(nullptr);
 	

--- a/TemplePlus/mainloop.cpp
+++ b/TemplePlus/mainloop.cpp
@@ -99,7 +99,7 @@ GameLoop::GameLoop(TigInitializer& tig, GameSystems& gameSystems, Updater &updat
 	: mTig(tig),
 	  mGameSystems(gameSystems),
 	  mUpdater(updater),
-	  mGameRenderer(tig, mGameSystems) {
+	  mGameRenderer(tig, gameView->GetCamera(), mGameSystems) {
 
 	mDiagScreen = std::make_unique<DiagScreen>(tig.GetRenderingDevice(),
 		gameSystems,
@@ -126,7 +126,7 @@ GameLoop::~GameLoop() {
 	temple_main, there is no need to hook this function in temple.dll
 */
 void GameLoop::Run() {
-	auto& camera = mTig.GetRenderingDevice().GetCamera();
+	auto& camera = gameView->GetCamera();
 	// Is this a center map kind of deal?
 	auto worldPos = camera.ScreenToWorld(400, 300);
 	locXY loc{ (uint32_t)(worldPos.x / INCH_PER_TILE), (uint32_t)(worldPos.z / INCH_PER_TILE) };
@@ -134,10 +134,9 @@ void GameLoop::Run() {
 
 	mainLoop.QueueFidgetAnimEvent();
 
-	GameView gameView(mTig.GetMainWindow(), mTig.GetRenderingDevice(), config.renderWidth, config.renderHeight);
-
 	TigMsg msg;
-	static eastl::deque<TigMsg> msgDebug;
+
+	auto& gameView = mTig.GetGameView();
 
 	auto quit = false;
 	while (!quit) {
@@ -226,8 +225,8 @@ void GameLoop::Run() {
 }
 
 void GameLoop::RenderFrame() {
-
-	auto& device = tig->GetRenderingDevice();
+	
+	auto& device = mTig.GetRenderingDevice();
 
 	// Recreate the render targets if AA changed
 	if (config.antialiasing != mSceneColor->IsMultiSampled()) {
@@ -240,6 +239,7 @@ void GameLoop::RenderFrame() {
 	device.BeginFrame();
 
 	device.PushRenderTarget(mSceneColor, mSceneDepth);
+	device.SetCurrentCamera(mTig.GetGameView().mCamera);
 
 	device.ClearCurrentColorTarget(XMCOLOR(0, 0, 0, 1));
 	device.ClearCurrentDepthTarget();
@@ -262,15 +262,16 @@ void GameLoop::RenderFrame() {
 
 	// Reset the render target
 	device.PopRenderTarget();
+	device.SetCurrentCamera(nullptr);
 	
 	// Copy from the actual render target to the back buffer and scale / position accordingly
 	TigRect destRect{ 
 		0, 
 		0,
-		(int) device.GetCamera().GetScreenWidth(),
-		(int) device.GetCamera().GetScreenHeight()
+		(int)device.GetCurrentCamera().GetScreenWidth(),
+		(int)device.GetCurrentCamera().GetScreenHeight()
 	};
-	TigRect srcRect{0, 0, config.renderWidth, config.renderHeight};
+	TigRect srcRect{0, 0, gameView->GetWidth(), gameView->GetHeight()};
 	srcRect.FitInto(destRect);
 
 	gfx::SamplerType2d samplerType = gfx::SamplerType2d::CLAMP;
@@ -297,13 +298,11 @@ void GameLoop::RenderFrame() {
 	static auto& gfadeEnabled = temple::GetRef<BOOL>(0x10D25118);
 	static auto& gfadeColor = temple::GetRef<XMCOLOR>(0x10D24A28);
 	if (gfadeEnabled) {
-		auto w = (float) device.GetCamera().GetScreenWidth();
-		auto h = (float)device.GetCamera().GetScreenHeight();
+		auto w = (float)device.GetCurrentCamera().GetScreenWidth();
+		auto h = (float)device.GetCurrentCamera().GetScreenHeight();
 		tig->GetShapeRenderer2d().DrawRectangle(0, 0, w, h, gfadeColor);
 	}
 	
-	// ImGui::ShowTestWindow();
-
 	device.Present();
 
 	device.EndPerfGroup();

--- a/TemplePlus/movies.cpp
+++ b/TemplePlus/movies.cpp
@@ -86,8 +86,8 @@ struct MovieRect {
 static MovieRect GetMovieRect(int movieWidth, int movieHeight) {
 	auto &device = tig->GetRenderingDevice();
 
-	auto screenWidth = device.GetCamera().GetScreenWidth();
-	auto screenHeight = device.GetCamera().GetScreenHeight();
+	auto screenWidth = device.GetCurrentCamera().GetScreenWidth();
+	auto screenHeight = device.GetCurrentCamera().GetScreenHeight();
 
 	// Fit movie into rect
 	float wFactor = screenWidth / movieWidth;
@@ -155,7 +155,7 @@ private:
 
 		auto extents = UiRenderer::MeasureTextSize(mLine->text, mSubtitleStyle, 700, 150);
 		
-		auto& camera = mDevice.GetCamera();
+		auto& camera = mDevice.GetCurrentCamera();
 
 		extents.x = (int)((camera.GetScreenWidth() - extents.width) / 2);
 		extents.y = (int)(camera.GetScreenHeight() - camera.GetScreenHeight() / 10);
@@ -312,7 +312,7 @@ int __cdecl HookedPlayMovieSlide(const char* imageFile, const char* soundFile, c
 
 	auto &textureSize = texture->GetSize();
 
-	auto &camera = device.GetCamera();
+	auto &camera = device.GetCurrentCamera();
 	TigRect bbRect(0, 0, (int)camera.GetScreenWidth(), (int)camera.GetScreenHeight());
 	TigRect destRect(0, 0, textureSize.width, textureSize.height);
 	destRect.FitInto(bbRect);

--- a/TemplePlus/path_node.cpp
+++ b/TemplePlus/path_node.cpp
@@ -1176,7 +1176,7 @@ void PathNodeSys::RenderPathNodes(int tileX1, int tileX2, int tileY1, int tileY2
 
 		if (node == mActivePathNode) {
 
-			auto topOfNode = gameView->GetCamera().WorldToScreenUi(pos);
+			auto topOfNode = gameView->WorldToScreenUi(pos);
 
 			renderer3d.DrawFilledCircle(pos, 8, activeNodeBorderColor, circleFillColor, false);
 			renderer3d.DrawFilledCircle(pos, 603, activeAoeBorderColor, circleFillColor, false);

--- a/TemplePlus/path_node.cpp
+++ b/TemplePlus/path_node.cpp
@@ -8,6 +8,7 @@
 #include "obj.h"
 #include "gamesystems/map/sector.h"
 #include "raycast.h"
+#include "gameview.h"
 
 //rendering
 #include <tig\tig_startup.h>
@@ -1175,7 +1176,7 @@ void PathNodeSys::RenderPathNodes(int tileX1, int tileX2, int tileY1, int tileY2
 
 		if (node == mActivePathNode) {
 
-			auto topOfNode = tig->GetRenderingDevice().GetCamera().WorldToScreenUi(pos);
+			auto topOfNode = gameView->GetCamera().WorldToScreenUi(pos);
 
 			renderer3d.DrawFilledCircle(pos, 8, activeNodeBorderColor, circleFillColor, false);
 			renderer3d.DrawFilledCircle(pos, 603, activeAoeBorderColor, circleFillColor, false);

--- a/TemplePlus/python/python_game.cpp
+++ b/TemplePlus/python/python_game.cpp
@@ -772,9 +772,9 @@ PyObject* PyGame_ObjCreate(PyObject*, PyObject* args) {
 	if (loc.locx == 0 && loc.locy == 0) {
 		auto mousePos = mouseFuncs.GetPos();
 		auto& device = tig->GetRenderingDevice();
-		auto worldPos = gameView->GetCamera().ScreenToWorld((float) mousePos.x, (float) mousePos.y);
+		auto worldPos = gameView->ScreenToWorld((float) mousePos.x, (float) mousePos.y);
 		loc.locx = (int)(worldPos.x / INCH_PER_TILE);
-		loc.locy = (int)(worldPos.x / INCH_PER_TILE);		
+		loc.locy = (int)(worldPos.x / INCH_PER_TILE);
 	}
 
 	// resolve the proto handle for the prototype number

--- a/TemplePlus/python/python_game.cpp
+++ b/TemplePlus/python/python_game.cpp
@@ -13,6 +13,7 @@
 #include "python_spell.h"
 #include "tig/tig_mouse.h"
 #include "maps.h"
+#include "../gameview.h"
 #include "../gamesystems/gamesystems.h"
 #include "../gamesystems/particlesystems.h"
 #include "../gamesystems/legacy.h"
@@ -771,7 +772,7 @@ PyObject* PyGame_ObjCreate(PyObject*, PyObject* args) {
 	if (loc.locx == 0 && loc.locy == 0) {
 		auto mousePos = mouseFuncs.GetPos();
 		auto& device = tig->GetRenderingDevice();
-		auto worldPos = device.GetCamera().ScreenToWorld((float) mousePos.x, (float) mousePos.y);
+		auto worldPos = gameView->GetCamera().ScreenToWorld((float) mousePos.x, (float) mousePos.y);
 		loc.locx = (int)(worldPos.x / INCH_PER_TILE);
 		loc.locy = (int)(worldPos.x / INCH_PER_TILE);		
 	}

--- a/TemplePlus/raycast.cpp
+++ b/TemplePlus/raycast.cpp
@@ -7,6 +7,7 @@
 #include <temple/dll.h>
 #include <tig/tig.h>
 #include <tig/tig_startup.h>
+#include "gameview.h"
 #include "gamesystems/gamesystems.h"
 #include "gamesystems/legacysystems.h"
 #include "gamesystems/legacymapsystems.h"
@@ -142,8 +143,7 @@ bool PickObjectOnScreen(int x, int y, objHndl * pickedHandle, GameRaycastFlags f
 		flags = GRF_HITTEST_3D;
 	}
 
-	auto &camera = tig->GetRenderingDevice().GetCamera();
-	auto worldCoord = camera.ScreenToWorld((float) x, (float) y);
+	auto worldCoord = gameView->GetCamera().ScreenToWorld((float) x, (float) y);
 
 	bool hitTest3d = flags & GRF_HITTEST_3D;
 	Ray3d ray;
@@ -155,7 +155,7 @@ bool PickObjectOnScreen(int x, int y, objHndl * pickedHandle, GameRaycastFlags f
 	float closestMeshHit = std::numeric_limits<float>::max();
 
 	if (hitTest3d) {
-		ray = tig->GetRenderingDevice().GetCamera().GetPickRay((float) x, (float) y);
+		ray = gameView->GetCamera().GetPickRay((float) x, (float) y);
 	}
 
 	auto worldLoc = LocAndOffsets::FromInches(worldCoord);

--- a/TemplePlus/raycast.cpp
+++ b/TemplePlus/raycast.cpp
@@ -143,7 +143,7 @@ bool PickObjectOnScreen(int x, int y, objHndl * pickedHandle, GameRaycastFlags f
 		flags = GRF_HITTEST_3D;
 	}
 
-	auto worldCoord = gameView->GetCamera().ScreenToWorld((float) x, (float) y);
+	auto worldCoord = gameView->ScreenToWorld((float) x, (float) y);
 
 	bool hitTest3d = flags & GRF_HITTEST_3D;
 	Ray3d ray;
@@ -155,7 +155,7 @@ bool PickObjectOnScreen(int x, int y, objHndl * pickedHandle, GameRaycastFlags f
 	float closestMeshHit = std::numeric_limits<float>::max();
 
 	if (hitTest3d) {
-		ray = gameView->GetCamera().GetPickRay((float) x, (float) y);
+		ray = gameView->GetPickRay((float) x, (float) y);
 	}
 
 	auto worldLoc = LocAndOffsets::FromInches(worldCoord);

--- a/TemplePlus/tig/tig_startup.cpp
+++ b/TemplePlus/tig/tig_startup.cpp
@@ -23,6 +23,8 @@
 #include "../tio/tio.h"
 #include "tig_console.h"
 
+#include "../gameview.h"
+
 #include "../config/config.h"
 #include <fstream>
 #include <mod_support.h>
@@ -151,6 +153,8 @@ TigInitializer::TigInitializer(HINSTANCE hInstance)
 	mConsole = std::make_unique<Console>();
 	// mStartedSystems.emplace_back(StartSystem("console.c", 0x101E0290, 0x101DFBC0));
 	mStartedSystems.emplace_back(StartSystem("loadscreen.c", 0x101E8260, TigShutdownNoop));
+
+	mGameView = std::make_unique<GameView>(*mMainWindow, *mRenderingDevice, config.renderWidth, config.renderHeight);
 
 	*tigInternal.consoleDisabled = false; // tig init disables console by default
 }

--- a/TemplePlus/tig/tig_startup.h
+++ b/TemplePlus/tig/tig_startup.h
@@ -73,6 +73,7 @@ namespace temple {
 class TextLayouter;
 class DebugUI;
 class Console;
+class GameView;
 
 // RAII for TIG initialization
 class TigInitializer {
@@ -128,6 +129,10 @@ public:
 		return *mMovieSystem;
 	}
 
+	GameView& GetGameView() {
+		return *mGameView;
+	}
+
 private:
 
 	using TigSystemPtr = std::unique_ptr<class LegacyTigSystem>;
@@ -157,6 +162,7 @@ private:
 	std::unique_ptr<temple::MovieSystem> mMovieSystem;
 	std::unique_ptr<class LegacyVideoSystem> mLegacyVideoSystem;
 	std::unique_ptr<class MessageQueue> mMessageQueue;
+	std::unique_ptr<GameView> mGameView;
 
 	// Contains all systems that have already been started
 	std::vector<TigSystemPtr> mStartedSystems;

--- a/TemplePlus/ui/ui.cpp
+++ b/TemplePlus/ui/ui.cpp
@@ -10,6 +10,7 @@
 #include "widgets/widgets.h"
 #include "gamesystems/gamesystems.h"
 #include "gamesystems/legacysystems.h"
+#include "gameview.h"
 
 UiManager *uiManager;
 
@@ -977,6 +978,11 @@ bool UiManager::ProcessMessage(TigMsg &msg)
 		return false;
 	}
 
+}
+
+gfx::Size UiManager::GetCanvasSize() const
+{
+	return { gameView->GetWidth(), gameView->GetHeight() };
 }
 
 bool UiManager::ProcessWidgetMessage(TigMsg & msg)

--- a/TemplePlus/ui/ui.h
+++ b/TemplePlus/ui/ui.h
@@ -7,6 +7,7 @@
 #include "tig/tig.h"
 #include <obj.h>
 #include <util/fixes.h>
+#include <graphics/textures.h>
 
 #define ACTIVE_WIDGET_CAP 3000
 
@@ -320,6 +321,16 @@ public:
 		if (mMouseCaptureWidgetId == widgetId) {
 			mMouseCaptureWidgetId = -1;
 		}
+	}
+
+	gfx::Size GetCanvasSize() const;
+
+	int GetCanvasWidth() const {
+		return GetCanvasSize().width;
+	}
+
+	int GetCanvasHeight() const {
+		return GetCanvasSize().height;
 	}
 
 private:

--- a/TemplePlus/ui/ui_ingame.cpp
+++ b/TemplePlus/ui/ui_ingame.cpp
@@ -250,7 +250,7 @@ void UiInGame::HandleNonCombatKeyStateChange(const TigMsg& msg){
 		else if (hotkeys.IsNormalNonreservedHotkey(msga.key)){
 			if (hotkeys.IsKeyPressed(VK_LCONTROL) || hotkeys.IsKeyPressed(VK_RCONTROL)) { // assign hotkey
 				auto leaderLoc = objects.GetLocationFull(leader);
-				auto screenPos = gameView->GetCamera().WorldToScreenUi(leaderLoc.ToInches3D());
+				auto screenPos = gameView->WorldToScreenUi(leaderLoc.ToInches3D());
 
 				radialMenus.SpawnMenu(int(screenPos.x), int(screenPos.y));
 				radialMenus.MsgHandler(&msg);

--- a/TemplePlus/ui/ui_ingame.cpp
+++ b/TemplePlus/ui/ui_ingame.cpp
@@ -9,6 +9,7 @@
 #include "ui_systems.h"
 #include "ui_legacysystems.h"
 #include "ui_dialog.h"
+#include "gameview.h"
 #include "gamesystems/gamesystems.h"
 #include "gamesystems/mapsystem.h"
 #include "gamesystems/mapobjrender.h"
@@ -249,7 +250,7 @@ void UiInGame::HandleNonCombatKeyStateChange(const TigMsg& msg){
 		else if (hotkeys.IsNormalNonreservedHotkey(msga.key)){
 			if (hotkeys.IsKeyPressed(VK_LCONTROL) || hotkeys.IsKeyPressed(VK_RCONTROL)) { // assign hotkey
 				auto leaderLoc = objects.GetLocationFull(leader);
-				auto screenPos = tig->GetRenderingDevice().GetCamera().WorldToScreenUi(leaderLoc.ToInches3D());
+				auto screenPos = gameView->GetCamera().WorldToScreenUi(leaderLoc.ToInches3D());
 
 				radialMenus.SpawnMenu(int(screenPos.x), int(screenPos.y));
 				radialMenus.MsgHandler(&msg);

--- a/TemplePlus/ui/ui_intgame_turnbased.cpp
+++ b/TemplePlus/ui/ui_intgame_turnbased.cpp
@@ -10,6 +10,7 @@
 #include "party.h"
 #include "obj.h"
 #include "util/fixes.h"
+#include "gameview.h"
 #include "tig/tig_msg.h"
 #include "ui/ui.h"
 #include "ui/ui_picker.h"
@@ -870,7 +871,7 @@ void UiIntegameTurnbasedRepl::RenderAooIndicator(const LocAndOffsets& location, 
 	auto texWidth = (float) texture->GetContentRect().width;
 	auto texHeight = (float) texture->GetContentRect().height;
 
-	auto screenPos = tig->GetRenderingDevice().GetCamera().WorldToScreenUi(location.ToInches3D());
+	auto screenPos = gameView->GetCamera().WorldToScreenUi(location.ToInches3D());
 	auto x = (float)(screenPos.x - texWidth / 2);
 	auto y = (float)(screenPos.y - texHeight / 2);
 

--- a/TemplePlus/ui/ui_intgame_turnbased.cpp
+++ b/TemplePlus/ui/ui_intgame_turnbased.cpp
@@ -871,7 +871,7 @@ void UiIntegameTurnbasedRepl::RenderAooIndicator(const LocAndOffsets& location, 
 	auto texWidth = (float) texture->GetContentRect().width;
 	auto texHeight = (float) texture->GetContentRect().height;
 
-	auto screenPos = gameView->GetCamera().WorldToScreenUi(location.ToInches3D());
+	auto screenPos = gameView->WorldToScreenUi(location.ToInches3D());
 	auto x = (float)(screenPos.x - texWidth / 2);
 	auto y = (float)(screenPos.y - texHeight / 2);
 

--- a/TemplePlus/ui/ui_townmap.cpp
+++ b/TemplePlus/ui/ui_townmap.cpp
@@ -137,7 +137,7 @@ void UiTownmap::PositionsInit(){
 	for (auto i = 0; i < N_maps; i++){
 		auto &pos = mPositions[i];
 		auto startLoc = gameSystems->GetMap().GetStartPos(i + 5000);	
-		pos = gameView->GetCamera().TileToWorld( startLoc );
+		pos = gameView->TileToWorld( startLoc );
 	}
 }
 

--- a/TemplePlus/ui/ui_townmap.cpp
+++ b/TemplePlus/ui/ui_townmap.cpp
@@ -133,12 +133,11 @@ void UiTownmap::Hide()
 
 void UiTownmap::PositionsInit(){
 	auto N_maps = gameSystems->GetMap().GetHighestMapId();
-	auto& device = tig->GetRenderingDevice();
 
 	for (auto i = 0; i < N_maps; i++){
 		auto &pos = mPositions[i];
 		auto startLoc = gameSystems->GetMap().GetStartPos(i + 5000);	
-		pos = device.GetCamera().TileToWorld( startLoc );
+		pos = gameView->GetCamera().TileToWorld( startLoc );
 	}
 }
 

--- a/TemplePlus/ui/widgets/widgets.cpp
+++ b/TemplePlus/ui/widgets/widgets.cpp
@@ -96,9 +96,7 @@ void WidgetBase::Render()
 	}
 
 	if (mSizeToParent) {
-		int containerWidth = mParent ? mParent->GetWidth() : (int)tig->GetRenderingDevice().GetCamera().GetScreenWidth();
-		int containerHeight = mParent ? mParent->GetHeight() : (int)tig->GetRenderingDevice().GetCamera().GetScreenHeight();
-		SetSize({ containerWidth, containerHeight });
+		SetSize(mParent ? mParent->GetSize() : uiManager->GetCanvasSize());
 	}
 
 	TigRect contentArea(GetContentArea());
@@ -119,7 +117,7 @@ void WidgetBase::Render()
 	}
 	
 	if (mCenterHorizontally) {
-		int containerWidth = mParent ? mParent->GetWidth() : (int)tig->GetRenderingDevice().GetCamera().GetScreenWidth();		
+		int containerWidth = mParent ? mParent->GetWidth() : uiManager->GetCanvasWidth();		
 		int x = (containerWidth - GetWidth()) / 2;
 		if (x != GetX()) {
 			SetX(x);
@@ -128,7 +126,7 @@ void WidgetBase::Render()
 	}
 
 	if (mCenterVertically) {
-		int containerHeight = mParent ? mParent->GetHeight() : (int)tig->GetRenderingDevice().GetCamera().GetScreenHeight();
+		int containerHeight = mParent ? mParent->GetHeight() : uiManager->GetCanvasHeight();
 		int y = (containerHeight - GetHeight()) / 2;
 		if (y != GetY()) {
 			SetY(y);

--- a/Tools/MdfPreviewNative/native.cpp
+++ b/Tools/MdfPreviewNative/native.cpp
@@ -85,7 +85,7 @@ struct LogAppender : spdlog::sinks::base_sink<std::mutex>
 
 struct MdfPreviewNative {
 	std::unique_ptr<RenderingDevice> device;
-	WorldCameraPtr camera;
+	WorldCamera* camera = nullptr;
 	VertexBufferPtr vertexBuffer;
 	IndexBufferPtr indexBuffer;
 	std::unique_ptr<BufferBinding> bufferBinding;	
@@ -155,7 +155,6 @@ API MdfPreviewNative* MdfPreviewNative_Load(const wchar_t* installPath,
 	
 	auto result(new MdfPreviewNative);
 	result->logAppender = debugSink;
-	result->camera = std::make_shared<WorldCamera>();
 	return result;
 }
 
@@ -168,7 +167,7 @@ API void MdfPreviewNative_InitDevice(MdfPreviewNative *native,
 	HWND handle,
 	int renderWidth, int renderHeight) {
 	native->device = std::make_unique<RenderingDevice>(handle);
-	native->device->SetCurrentCamera(native->camera);
+	native->camera = &native->device->GetCurrentCamera();
 
 	std::array<MdfVertex, 4> corners;
 	corners[0].pos = XMFLOAT4(-1, 1, 0.5f, 1);

--- a/Tools/MdfPreviewNative/native.cpp
+++ b/Tools/MdfPreviewNative/native.cpp
@@ -85,6 +85,7 @@ struct LogAppender : spdlog::sinks::base_sink<std::mutex>
 
 struct MdfPreviewNative {
 	std::unique_ptr<RenderingDevice> device;
+	WorldCameraPtr camera;
 	VertexBufferPtr vertexBuffer;
 	IndexBufferPtr indexBuffer;
 	std::unique_ptr<BufferBinding> bufferBinding;	
@@ -154,6 +155,7 @@ API MdfPreviewNative* MdfPreviewNative_Load(const wchar_t* installPath,
 	
 	auto result(new MdfPreviewNative);
 	result->logAppender = debugSink;
+	result->camera = std::make_shared<WorldCamera>();
 	return result;
 }
 
@@ -166,6 +168,7 @@ API void MdfPreviewNative_InitDevice(MdfPreviewNative *native,
 	HWND handle,
 	int renderWidth, int renderHeight) {
 	native->device = std::make_unique<RenderingDevice>(handle);
+	native->device->SetCurrentCamera(native->camera);
 
 	std::array<MdfVertex, 4> corners;
 	corners[0].pos = XMFLOAT4(-1, 1, 0.5f, 1);
@@ -267,11 +270,11 @@ API void MdfPreviewNative_FreeDevice(MdfPreviewNative *native) {
 }
 
 API void MdfPreviewNative_SetCameraPos(MdfPreviewNative *native, float x, float y) {
-	native->device->GetCamera().SetTranslation(x, y);
+	native->camera->SetTranslation(x, y);
 }
 API void MdfPreviewNative_GetCameraPos(MdfPreviewNative *native, float* x, float* y) {
 	
-	auto translation = native->device->GetCamera().GetTranslation();
+	auto translation = native->camera->GetTranslation();
 	*x = translation.x;
 	*y = translation.y;
 
@@ -291,7 +294,7 @@ API void MdfPreviewNative_Render(MdfPreviewNative *native) {
 	globalLight.range = 800;
 		
 	if (native->material) {
-		native->device->GetCamera().SetIdentityTransform(true);
+		native->camera->SetIdentityTransform(true);
 
 		std::vector<Light3d> lights{ globalLight };
 		native->material->Bind(*native->device, lights);
@@ -301,7 +304,7 @@ API void MdfPreviewNative_Render(MdfPreviewNative *native) {
 	}
 
 	if (native->model) {
-		native->device->GetCamera().SetIdentityTransform(false);
+		native->camera->SetIdentityTransform(false);
 
 		globalLight.color = XMFLOAT4(1, 1, 1, 1);
 		globalLight.dir = XMFLOAT4(-0.6324094f, -0.7746344f, 0, 0);
@@ -322,7 +325,7 @@ API bool MdfPreviewNative_SetModel(MdfPreviewNative *native,
 	const char *skaFilename) {
 
 	native->material.reset();
-	native->device->GetCamera().CenterOn(0, 0, 0);
+	native->camera->CenterOn(0, 0, 0);
 
 	try {
 		EncodedAnimId idleId(WeaponAnim::Idle);
@@ -457,7 +460,7 @@ API void MdfPreviewNative_SetRotation(MdfPreviewNative *native, float rotation) 
 }
 
 API void MdfPreviewNative_SetScale(MdfPreviewNative *native, float scale) {
-	native->device->GetCamera().SetScale(scale);
+	native->camera->SetScale(scale);
 }
 
 void MdfPreviewNative::SpawnParticles(const std::string &name) {
@@ -606,7 +609,7 @@ bool PartSysExternal::GetBonePos(ObjHndl obj, int boneIdx, Vec3& pos) {
 
 void PartSysExternal::WorldToScreen(const Vec3& worldPos, Vec2& screenPos) {
 
-	screenPos = mNative.device->GetCamera().WorldToScreen(worldPos);
+	screenPos = mNative.camera->WorldToScreen(worldPos);
 
 }
 
@@ -615,7 +618,7 @@ API void MdfPreviewNative_SetRenderSize(MdfPreviewNative *native, int w, int h) 
 }
 
 API void MdfPreviewNative_ScreenToWorld(MdfPreviewNative *native, float x, float y, float* xOut, float *yOut, float *zOut) {
-	auto world = native->device->GetCamera().ScreenToWorld(x, y);
+	auto world = native->camera->ScreenToWorld(x, y);
 	*xOut = world.x;
 	*yOut = world.y;
 	*zOut = world.z;

--- a/Tools/ParticleEditorNative/ParticleEditorNative.cpp
+++ b/Tools/ParticleEditorNative/ParticleEditorNative.cpp
@@ -51,11 +51,11 @@ extern "C" {
 	}
 
 	API void ParticleSystem_SetPos(TempleDll* dll, float screenX, float screenY) {
-		auto worldPos = dll->renderingDevice.GetCamera().ScreenToWorld(screenX, screenY);
+		auto worldPos = dll->camera->ScreenToWorld(screenX, screenY);
 	}
 
 	API void ParticleSystem_SetObjPos(TempleDll* dll, float screenX, float screenY) {
-		auto worldPos = dll->renderingDevice.GetCamera().ScreenToWorld(screenX, screenY);
+		auto worldPos = dll->camera->ScreenToWorld(screenX, screenY);
 	}
 
 	API void ParticleSystem_Render(TempleDll* dll) {

--- a/Tools/ParticleEditorNative/ParticleEditorNative.cpp
+++ b/Tools/ParticleEditorNative/ParticleEditorNative.cpp
@@ -51,11 +51,11 @@ extern "C" {
 	}
 
 	API void ParticleSystem_SetPos(TempleDll* dll, float screenX, float screenY) {
-		auto worldPos = dll->camera->ScreenToWorld(screenX, screenY);
+		auto worldPos = dll->camera.ScreenToWorld(screenX, screenY);
 	}
 
 	API void ParticleSystem_SetObjPos(TempleDll* dll, float screenX, float screenY) {
-		auto worldPos = dll->camera->ScreenToWorld(screenX, screenY);
+		auto worldPos = dll->camera.ScreenToWorld(screenX, screenY);
 	}
 
 	API void ParticleSystem_Render(TempleDll* dll) {

--- a/Tools/ParticleEditorNative/api.h
+++ b/Tools/ParticleEditorNative/api.h
@@ -6,6 +6,7 @@
 #define API __declspec(dllexport)
 
 #include <graphics/device.h>
+#include <graphics/camera.h>
 #include <graphics/mdfmaterials.h>
 #include <graphics/shaperenderer2d.h>
 #include <graphics/shaperenderer3d.h>
@@ -29,6 +30,7 @@ struct TempleDll {
 	static temple::AasConfig CreateAasConfig();
 
 	gfx::RenderingDevice renderingDevice;
+	gfx::WorldCameraPtr camera;
 	gfx::MdfMaterialFactory mdfFactory;
 	temple::AasConfig aasConfig;
 	gfx::ShapeRenderer2d shapeRenderer2d;

--- a/Tools/ParticleEditorNative/api.h
+++ b/Tools/ParticleEditorNative/api.h
@@ -30,7 +30,7 @@ struct TempleDll {
 	static temple::AasConfig CreateAasConfig();
 
 	gfx::RenderingDevice renderingDevice;
-	gfx::WorldCameraPtr camera;
+	gfx::WorldCamera &camera;
 	gfx::MdfMaterialFactory mdfFactory;
 	temple::AasConfig aasConfig;
 	gfx::ShapeRenderer2d shapeRenderer2d;

--- a/Tools/ParticleEditorNative/dll.cpp
+++ b/Tools/ParticleEditorNative/dll.cpp
@@ -14,6 +14,7 @@ std::string lastError;
 
 TempleDll::TempleDll(const std::wstring &installationDir)
 	: renderingDevice(nullptr, 0, true),
+	camera(std::make_shared<gfx::WorldCamera>()),
 	mdfFactory(renderingDevice),
 	aasConfig(CreateAasConfig()),
 	aasFactory(aasConfig),
@@ -21,6 +22,8 @@ TempleDll::TempleDll(const std::wstring &installationDir)
 	shapeRenderer3d(renderingDevice),
 	aasRenderer(aasFactory, renderingDevice, shapeRenderer2d, shapeRenderer3d, mdfFactory),
 	renderManager(renderingDevice, aasFactory, aasRenderer) {
+
+	renderingDevice.SetCurrentCamera(camera);
 
 	animParams.rotation = XMConvertToRadians(135.0f);
 
@@ -119,9 +122,9 @@ void TempleDll_SetRenderTarget(TempleDll *templeDll, IUnknown *surface) {
 
 void TempleDll_CenterOn(TempleDll *dll, float x, float y, float z)
 {
-	dll->renderingDevice.GetCamera().CenterOn(x, y, z);
+	dll->camera->CenterOn(x, y, z);
 }
 
 void TempleDll_SetScale(TempleDll *templeDll, float scale) {
-	templeDll->renderingDevice.GetCamera().SetScale(scale);
+	templeDll->camera->SetScale(scale);
 }

--- a/Tools/ParticleEditorNative/dll.cpp
+++ b/Tools/ParticleEditorNative/dll.cpp
@@ -14,7 +14,7 @@ std::string lastError;
 
 TempleDll::TempleDll(const std::wstring &installationDir)
 	: renderingDevice(nullptr, 0, true),
-	camera(std::make_shared<gfx::WorldCamera>()),
+	camera(renderingDevice.GetCurrentCamera()),
 	mdfFactory(renderingDevice),
 	aasConfig(CreateAasConfig()),
 	aasFactory(aasConfig),
@@ -22,8 +22,6 @@ TempleDll::TempleDll(const std::wstring &installationDir)
 	shapeRenderer3d(renderingDevice),
 	aasRenderer(aasFactory, renderingDevice, shapeRenderer2d, shapeRenderer3d, mdfFactory),
 	renderManager(renderingDevice, aasFactory, aasRenderer) {
-
-	renderingDevice.SetCurrentCamera(camera);
 
 	animParams.rotation = XMConvertToRadians(135.0f);
 
@@ -122,9 +120,9 @@ void TempleDll_SetRenderTarget(TempleDll *templeDll, IUnknown *surface) {
 
 void TempleDll_CenterOn(TempleDll *dll, float x, float y, float z)
 {
-	dll->camera->CenterOn(x, y, z);
+	dll->camera.CenterOn(x, y, z);
 }
 
 void TempleDll_SetScale(TempleDll *templeDll, float scale) {
-	templeDll->camera->SetScale(scale);
+	templeDll->camera.SetScale(scale);
 }

--- a/Tools/ParticleEditorNative/video.cpp
+++ b/Tools/ParticleEditorNative/video.cpp
@@ -80,7 +80,7 @@ bool ParticleSystem_RenderVideo(TempleDll *dll, XMCOLOR background, const wchar_
 	
 	dll->renderingDevice.PushRenderTarget(renderTarget, depthTarget);
 
-	dll->camera->CenterOn(0, 0, 0);
+	dll->camera.CenterOn(0, 0, 0);
 
 	int frameId = 0;
 

--- a/Tools/ParticleEditorNative/video.cpp
+++ b/Tools/ParticleEditorNative/video.cpp
@@ -80,7 +80,7 @@ bool ParticleSystem_RenderVideo(TempleDll *dll, XMCOLOR background, const wchar_
 	
 	dll->renderingDevice.PushRenderTarget(renderTarget, depthTarget);
 
-	dll->renderingDevice.GetCamera().CenterOn(0, 0, 0);
+	dll->camera->CenterOn(0, 0, 0);
 
 	int frameId = 0;
 


### PR DESCRIPTION
Reduce reliance on RenderingDevice::GetCamera() since it can switch projection when the render target changes. This causes issues if any code in ProcessMessage/AdvanceTime makes use of the camera to determine visibility of objects (i.e. particle systems). This happens because the gameView render target is only pushed during RenderFrame and when it is popped after rendering is done, the RenderingDevice will automatically call SetScreenSize on the camera using the backbuffer's size.

Instead, use GameView (global 'gameView') to keep a camera that always represents the view/projection of the actual game view, which is never touched.

This should fix #462.