### PR TITLE
Create generic_monster_dr.py

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/generic_monster_dr.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/generic_monster_dr.py
@@ -1,0 +1,22 @@
+from templeplus.pymod import PythonModifier
+from toee import *
+import tpdp
+
+### Generic Monster DR Condition
+
+def grantMonsterDr(attachee, args, evt_obj):
+    drAmount = args.get_arg(0)
+    drBreakType = args.get_arg(1)
+    damageMesId = 126 #ID126 in damage.mes = ~Damage Reduction~[TAG_SPECIAL_ABILITIES_DAMAGE_REDUCTION]
+    evt_obj.damage_packet.add_physical_damage_res(drAmount, drBreakType, damageMesId)
+    return 0
+
+def breakCritterDr(attachee, args, evt_obj):
+    drBreakType = args.get_arg(1)
+    if not evt_obj.damage_packet.attack_power & drBreakType:
+        evt_obj.damage_packet.attack_power |= drBreakType
+    return 0
+
+genericMonsterDR = PythonModifier("Generic Monster DR", 2) #arg1: DR Amount, arg2: DR Type
+genericMonsterDR.AddHook(ET_OnTakingDamage2, EK_NONE, grantMonsterDr, ())
+genericMonsterDR.AddHook(ET_OnDealingDamage, EK_NONE, breakCritterDr, ())


### PR DESCRIPTION
Converted to Draft because my condition does not have the query all monster DR's have, e.g. https://github.com/GrognardsFromHell/DllDocumentation/wiki/Conditions-(List)-page-2-M-Z#monster-dr-holy

If I understand it correctly, It just checks if data1(which would be arg2 in my condition) has a valid (>0) value and if not it prints a debug msg

Should I add it to the generic_monster_dr.py or not? Can't see a real benefit.