### PR TITLE
Remove 3.0 limitation of medium size for 'person' targets

### DIFF
--- a/tpdatasrc/co8infra/rules/spells/588 - Mass Hold Person.txt
+++ b/tpdatasrc/co8infra/rules/spells/588 - Mass Hold Person.txt
@@ -1,0 +1,21 @@
+School: Enchantment
+Subschool: Compulsion
+Descriptor: Mind-Affecting
+Level: Sor 7
+Level: Wiz 7
+Component: V
+Component: S
+Casting Time: 1 action
+Range: Medium
+Saving Throw: Willpower
+Spell Resistance: Yes
+Projectile: No
+flags_Target: Range
+inc_flags_Target: Self
+inc_flags_Target: Other
+exc_flags_Target: Dead
+exc_flags_Target: Non-critter
+exc_flags_Target: Friendly
+mode_Target: Area
+radius_Target: 30
+ai_type: ai_action_offensive

--- a/tpdatasrc/co8infra/rules/spells/588 - Mass Hold Person.txt
+++ b/tpdatasrc/co8infra/rules/spells/588 - Mass Hold Person.txt
@@ -15,7 +15,11 @@ inc_flags_Target: Self
 inc_flags_Target: Other
 exc_flags_Target: Dead
 exc_flags_Target: Non-critter
-exc_flags_Target: Friendly
-mode_Target: Area
-radius_Target: 30
+mode_Target: Multi
+mode_Target: Once-Multi
+mode_Target: Any 30 Feet
+mode_Target: End Early Multi
+radius_Target: 0
+min_Target: 1
+max_Target: 99
 ai_type: ai_action_offensive

--- a/tpdatasrc/co8infra/rules/spells/588 - Mass Hold Person.txt
+++ b/tpdatasrc/co8infra/rules/spells/588 - Mass Hold Person.txt
@@ -21,5 +21,5 @@ mode_Target: Any 30 Feet
 mode_Target: End Early Multi
 radius_Target: 0
 min_Target: 1
-max_Target: 99
+max_Target: 30
 ai_type: ai_action_offensive

--- a/tpdatasrc/co8infra/scr/Spell056 - Charm Person.py
+++ b/tpdatasrc/co8infra/scr/Spell056 - Charm Person.py
@@ -25,7 +25,7 @@ def	OnSpellEffect( spell ):
 			target_item_obj = target_item.obj
 
 	if not target_item_obj.is_friendly( spell.caster ):
-		if (target_item_obj.is_category_type( mc_type_humanoid )) and (target_item_obj.get_size < STAT_SIZE_LARGE):
+		if target_item_obj.is_category_type( mc_type_humanoid ):
 
 			if not target_item_obj.saving_throw_spell( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, spell.id ):
 				# saving throw unsuccessful

--- a/tpdatasrc/co8infra/scr/Spell152 - Enlarge.py
+++ b/tpdatasrc/co8infra/scr/Spell152 - Enlarge.py
@@ -72,6 +72,13 @@ def OnSpellEffect( spell ):
 
 				game.particles( 'Fizzle', target_item.obj )
 				spell.target_list.remove_target( target_item.obj )
+	else: # not a humanoid
+		target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
+		target_item.obj.float_mesfile_line( 'mes\\spell.mes', 31004 )
+
+		game.particles( 'Fizzle', target_item.obj )
+		spell.target_list.remove_target( target_item.obj )
+
 	print "spell.target_list=", spell.target_list
 	spell.spell_end( spell.id )
 

--- a/tpdatasrc/co8infra/scr/Spell152 - Enlarge.py
+++ b/tpdatasrc/co8infra/scr/Spell152 - Enlarge.py
@@ -45,6 +45,9 @@ def OnSpellEffect( spell ):
 
 
 				target_item.partsys_id = game.particles( 'sp-Enlarge', target_item.obj )
+			else:
+				# sp-Enlarge not applied, probably dispelled sp-Reduce
+				spell.target_list.remove_target(target_item.obj)
 		else:
 			if not target_item.obj.saving_throw_spell( spell.dc, D20_Save_Fortitude, D20STD_F_NONE, spell.caster, spell.id ):
 
@@ -61,13 +64,16 @@ def OnSpellEffect( spell ):
 				if return_val == 1:
 					target_item.partsys_id = game.particles( 'sp-Enlarge', target_item.obj )
 				else:
-					# saving throw successful
-					target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
+					# sp-Enlarge not applied, probably dispelled sp-Reduce
+					spell.target_list.remove_target(target_item.obj)
+			else:
+				# saving throw successful
+				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
 
-					game.particles( 'Fizzle', target_item.obj )
-	#								spell.target_list.remove_target( target_item.obj )
+				game.particles( 'Fizzle', target_item.obj )
+				spell.target_list.remove_target( target_item.obj )
 	print "spell.target_list=", spell.target_list
-#	spell.spell_end( spell.id )
+	spell.spell_end( spell.id )
 
 
 def OnBeginRound( spell ):

--- a/tpdatasrc/co8infra/scr/Spell228 - Hold Person.py
+++ b/tpdatasrc/co8infra/scr/Spell228 - Hold Person.py
@@ -18,66 +18,57 @@ def OnSpellEffect( spell ):
 
 
 	if npc.type != obj_t_pc and npc.leader_get() == OBJ_HANDLE_NULL:
-		if target.obj.is_category_type( mc_type_humanoid ) and target.obj.get_size < STAT_SIZE_LARGE and critter_is_unconscious(target.obj) != 1 and not target.obj.d20_query(Q_Prone):
+		if target.obj.is_category_type( mc_type_humanoid ) and critter_is_unconscious(target.obj) != 1 and not target.obj.d20_query(Q_Prone):
 			npc = spell.caster
 		else:
 			game.global_flags[811] = 0
 
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 5 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 5 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid )  and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 10 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 10 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 15 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 15 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 20 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 20 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 25 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 25 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 30 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 30 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 			for obj in game.party[0].group_list():
-				if obj.distance_to(npc) <= 100 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+				if obj.distance_to(npc) <= 100 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 					target.obj = obj
 					game.global_flags[811] = 1
 	
 	if target.obj.is_category_type( mc_type_humanoid ):
 
-		if target.obj.get_size < STAT_SIZE_LARGE:
+		# allow Will saving throw to negate
+		if target.obj.saving_throw_spell( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, spell.id ):
 
-			# allow Will saving throw to negate
-			if target.obj.saving_throw_spell( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, spell.id ):
-
-				# saving throw successful
-				target.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
-
-				game.particles( 'Fizzle', target.obj )
-				spell.target_list.remove_target( target.obj )
-			else:
-				# saving throw unsuccessful
-				target.obj.float_mesfile_line( 'mes\\spell.mes', 30002 )
-
-				# HTN - apply condition HOLD (paralyzed)
-				target.obj.condition_add_with_args( 'sp-Hold Person', spell.id, spell.duration, 0 )
-				target.partsys_id = game.particles( 'sp-Hold Person', target.obj )
-		else:
-			# not medium sized or smaller
-			target.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
-			targe.obj.float_mesfile_line( 'mes\\spell.mes', 31005 )
+			# saving throw successful
+			target.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
 
 			game.particles( 'Fizzle', target.obj )
 			spell.target_list.remove_target( target.obj )
+		else:
+			# saving throw unsuccessful
+			target.obj.float_mesfile_line( 'mes\\spell.mes', 30002 )
+
+			# HTN - apply condition HOLD (paralyzed)
+			target.obj.condition_add_with_args( 'sp-Hold Person', spell.id, spell.duration, 0 )
+			target.partsys_id = game.particles( 'sp-Hold Person', target.obj )
 
 	else:
 		# not a person

--- a/tpdatasrc/co8infra/scr/Spell386 - Reduce.py
+++ b/tpdatasrc/co8infra/scr/Spell386 - Reduce.py
@@ -1,0 +1,61 @@
+from toee import *
+
+def OnBeginSpellCast( spell ):
+	print "Reduce OnBeginSpellCast"
+	print "spell.target_list=", spell.target_list
+	print "spell.caster=", spell.caster, " caster.level= ", spell.caster_level
+	game.particles( "sp-transmutation-conjure", spell.caster )
+
+def	OnSpellEffect( spell ):
+	print "Reduce OnSpellEffect"
+
+	spell.duration = 10 * spell.caster_level
+	target_item = spell.target_list[0]
+
+	if target_item.obj.is_friendly( spell.caster ):
+		if (target_item.obj.is_category_type( mc_type_humanoid )) and (target_item.obj.get_size < STAT_SIZE_LARGE):
+			return_val = target_item.obj.condition_add_with_args( 'sp-Reduce', spell.id, spell.duration, 0 )
+			if return_val == 1:
+				target_item.partsys_id = game.particles( 'sp-Reduce Person', target_item.obj )
+
+		else:
+			# not a humanoid
+			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
+			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 31004 )
+
+			game.particles( 'Fizzle', target_item.obj )
+			spell.target_list.remove_target( target_item.obj )
+
+	else:
+		if (target_item.obj.is_category_type( mc_type_humanoid )) and (target_item.obj.get_size < STAT_SIZE_LARGE):
+			if not target_item.obj.saving_throw_spell( spell.dc, D20_Save_Fortitude, D20STD_F_NONE, spell.caster, spell.id ):
+
+				# saving throw unsuccesful
+				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30002 )
+
+				return_val = target_item.obj.condition_add_with_args( 'sp-Reduce', spell.id, spell.duration, 0 )
+				if return_val == 1:
+					target_item.partsys_id = game.particles( 'sp-Reduce Person', target_item.obj )
+
+			else:
+
+				# saving throw successful
+				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
+
+				game.particles( 'Fizzle', target_item.obj )
+				spell.target_list.remove_target( target_item.obj )
+		else:
+			# not a humanoid
+			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
+			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 31004 )
+
+			game.particles( 'Fizzle', target_item.obj )
+			spell.target_list.remove_target( target_item.obj )
+
+	spell.spell_end( spell.id )
+
+def OnBeginRound( spell ):
+	print "Reduce OnBeginRound"
+
+def OnEndSpellCast( spell ):
+	print "Reduce OnEndSpellCast"

--- a/tpdatasrc/co8infra/scr/Spell386 - Reduce.py
+++ b/tpdatasrc/co8infra/scr/Spell386 - Reduce.py
@@ -13,7 +13,7 @@ def	OnSpellEffect( spell ):
 	target_item = spell.target_list[0]
 
 	if target_item.obj.is_friendly( spell.caster ):
-		if (target_item.obj.is_category_type( mc_type_humanoid )) and (target_item.obj.get_size < STAT_SIZE_LARGE):
+		if target_item.obj.is_category_type( mc_type_humanoid ):
 			return_val = target_item.obj.condition_add_with_args( 'sp-Reduce', spell.id, spell.duration, 0 )
 			if return_val == 1:
 				target_item.partsys_id = game.particles( 'sp-Reduce Person', target_item.obj )
@@ -27,7 +27,7 @@ def	OnSpellEffect( spell ):
 			spell.target_list.remove_target( target_item.obj )
 
 	else:
-		if (target_item.obj.is_category_type( mc_type_humanoid )) and (target_item.obj.get_size < STAT_SIZE_LARGE):
+		if target_item.obj.is_category_type( mc_type_humanoid ):
 			if not target_item.obj.saving_throw_spell( spell.dc, D20_Save_Fortitude, D20STD_F_NONE, spell.caster, spell.id ):
 
 				# saving throw unsuccesful

--- a/tpdatasrc/co8infra/scr/Spell386 - Reduce.py
+++ b/tpdatasrc/co8infra/scr/Spell386 - Reduce.py
@@ -17,6 +17,9 @@ def	OnSpellEffect( spell ):
 			return_val = target_item.obj.condition_add_with_args( 'sp-Reduce', spell.id, spell.duration, 0 )
 			if return_val == 1:
 				target_item.partsys_id = game.particles( 'sp-Reduce Person', target_item.obj )
+			else:
+				# sp-Reduce not added, probably dispelled sp-Enlarge
+				spell.target_list.remove_target(target_item.obj)
 
 		else:
 			# not a humanoid
@@ -36,6 +39,9 @@ def	OnSpellEffect( spell ):
 				return_val = target_item.obj.condition_add_with_args( 'sp-Reduce', spell.id, spell.duration, 0 )
 				if return_val == 1:
 					target_item.partsys_id = game.particles( 'sp-Reduce Person', target_item.obj )
+				else:
+					# sp-Reduce not added, probably dispelled sp-Enlarge
+					spell.target_list.remove_target(target_item.obj)
 
 			else:
 

--- a/tpdatasrc/co8infra/scr/Spell588 - Mass Hold Person.py
+++ b/tpdatasrc/co8infra/scr/Spell588 - Mass Hold Person.py
@@ -18,67 +18,56 @@ def OnSpellEffect( spell ):
 
 		npc = spell.caster			##  added so NPC's will choose valid targets
 		if npc.type != obj_t_pc and npc.leader_get() == OBJ_HANDLE_NULL:
-			if target_item.obj.is_category_type( mc_type_humanoid ) and target_item.obj.get_size < STAT_SIZE_LARGE and critter_is_unconscious(target_item.obj) != 1 and not target_item.obj.d20_query(Q_Prone):
+			if target_item.obj.is_category_type( mc_type_humanoid ) and critter_is_unconscious(target_item.obj) != 1 and not target_item.obj.d20_query(Q_Prone):
 				npc = spell.caster
 			else:
 				game.global_flags[811] = 0	
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 5 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 5 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 10 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 10 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 15 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 15 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 20 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 20 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 25 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 25 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 30 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 30 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 				for obj in game.party[0].group_list():
-					if obj.distance_to(npc) <= 100 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+					if obj.distance_to(npc) <= 100 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
 						target_item.obj = obj
 						game.global_flags[811] = 1
 
 				
 		if target_item.obj.is_category_type( mc_type_humanoid ):
+			# allow Will saving throw to negate
+			if target_item.obj.saving_throw_spell( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, spell.id ):
 
-			if target_item.obj.get_size < STAT_SIZE_LARGE:
-
-				# allow Will saving throw to negate
-				if target_item.obj.saving_throw_spell( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, spell.id ):
-
-					# saving throw successful
-					target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
-
-					game.particles( 'Fizzle', target_item.obj )
-					remove_list.append( target_item.obj )
-				else:
-					# saving throw unsuccessful
-					target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30002 )
-
-					# HTN - apply condition HOLD (paralyzed)
-					target_item.obj.condition_add_with_args( 'sp-Hold Person', spell.id, spell.duration, 0 )
-					target_item.partsys_id = game.particles( 'sp-Hold Person', target_item.obj )
-			else:
-				# not medium sized or smaller
-				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
-				targe.obj.float_mesfile_line( 'mes\\spell.mes', 31005 )
+				# saving throw successful
+				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
 
 				game.particles( 'Fizzle', target_item.obj )
 				remove_list.append( target_item.obj )
+			else:
+				# saving throw unsuccessful
+				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30002 )
 
+				# HTN - apply condition HOLD (paralyzed)
+				target_item.obj.condition_add_with_args( 'sp-Hold Person', spell.id, spell.duration, 0 )
+				target_item.partsys_id = game.particles( 'sp-Hold Person', target_item.obj )
 		else:
 			# not a person
 			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )

--- a/tpdatasrc/co8infra/scr/Spell588 - Mass Hold Person.py
+++ b/tpdatasrc/co8infra/scr/Spell588 - Mass Hold Person.py
@@ -1,0 +1,98 @@
+from utilities import *
+from toee import *
+
+def OnBeginSpellCast( spell ):
+	print "Hold Person OnBeginSpellCast"
+	print "spell.target_list=", spell.target_list
+	print "spell.caster=", spell.caster, " caster.level= ", spell.caster_level
+	game.particles( "sp-enchantment-conjure", spell.caster )
+
+def OnSpellEffect( spell ):
+	print "Hold Person OnSpellEffect"
+
+	spell.duration = 1 * spell.caster_level
+
+	remove_list = []
+
+	for target_item in spell.target_list:
+
+		npc = spell.caster			##  added so NPC's will choose valid targets
+		if npc.type != obj_t_pc and npc.leader_get() == OBJ_HANDLE_NULL:
+			if target_item.obj.is_category_type( mc_type_humanoid ) and target_item.obj.get_size < STAT_SIZE_LARGE and critter_is_unconscious(target_item.obj) != 1 and not target_item.obj.d20_query(Q_Prone):
+				npc = spell.caster
+			else:
+				game.global_flags[811] = 0	
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 5 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 10 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 15 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 20 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 25 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 30 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+				for obj in game.party[0].group_list():
+					if obj.distance_to(npc) <= 100 and critter_is_unconscious(obj) != 1 and obj.is_category_type( mc_type_humanoid ) and obj.get_size < STAT_SIZE_LARGE and game.global_flags[811] == 0 and not obj.d20_query(Q_Prone):
+						target_item.obj = obj
+						game.global_flags[811] = 1
+
+				
+		if target_item.obj.is_category_type( mc_type_humanoid ):
+
+			if target_item.obj.get_size < STAT_SIZE_LARGE:
+
+				# allow Will saving throw to negate
+				if target_item.obj.saving_throw_spell( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, spell.id ):
+
+					# saving throw successful
+					target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30001 )
+
+					game.particles( 'Fizzle', target_item.obj )
+					remove_list.append( target_item.obj )
+				else:
+					# saving throw unsuccessful
+					target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30002 )
+
+					# HTN - apply condition HOLD (paralyzed)
+					target_item.obj.condition_add_with_args( 'sp-Hold Person', spell.id, spell.duration, 0 )
+					target_item.partsys_id = game.particles( 'sp-Hold Person', target_item.obj )
+			else:
+				# not medium sized or smaller
+				target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
+				targe.obj.float_mesfile_line( 'mes\\spell.mes', 31005 )
+
+				game.particles( 'Fizzle', target_item.obj )
+				remove_list.append( target_item.obj )
+
+		else:
+			# not a person
+			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 30000 )
+			target_item.obj.float_mesfile_line( 'mes\\spell.mes', 31004 )
+
+			game.particles( 'Fizzle', target_item.obj )
+			remove_list.append( target_item.obj )
+
+	spell.target_list.remove_list( remove_list )
+	spell.spell_end( spell.id )
+
+def OnBeginRound( spell ):
+	print "Hold Person OnBeginRound"
+
+def OnEndSpellCast( spell ):
+	print "Hold Person OnEndSpellCast"
+


### PR DESCRIPTION
Several 3.0 spells had limitations on size rather than just humanoid targets. Since ToEE started as a 3.0 game (I think) these got written and never reviewed in the rules update.

This is a problem in that Enlarge Person increases your size (which it didn't in 3.0), and makes you immune to these spells, including Reduce Person, which is supposed to dispel it.

I also fixed some problems with Enlarge/Reduce. There were code paths that would leave the spell dangling forever (when one dispels the other). Enlarge also had some missing logic apparently from the Co8 rewrite to fix the size/reach stuff for PCs.

There are actually other spells with this logic.
1. Greater Command: The by-the-book limitation on the spell is that the caster needs to know a language that the target understands, but I don't think that's something that ToEE really tracks. The lesser version allows any humanoid or <large creature to be a target, but Greater just allows <large.
2. Mass Hold Person: This one seemed a little less urgent since it's high level. I also noticed that the targeting is wrong. It's doing 30ft radius enemies instead of Any 30 Feet (which is more like a 15ft radius). I can fix one or both of these, but I'm not sure which folders they should go in. Both co8infra and kotbfixes?

One thing I should note is that the fixed endless spell case for Enlarge Person causes complaints in the console because of its reach fix. However, I was wondering if maybe the reach calculation should just be replaced in Temple+ so that that fixup isn't necessary anymore. Reach is also not correctly calculated when you reduce a small character (they should have 0 natural reach, but it's set to 5).