### PR TITLE
Divine spell power was doubling caster level

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/divine_spell_power.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/divine_spell_power.py
@@ -79,7 +79,7 @@ def DivineSpellPowerCasterLevelBonus(attachee, args, evt_obj):
 		# Prevent invalid caster levels
 		casterBonus = args.get_arg(1)
 		casterLevel = evt_obj.return_val + casterBonus
-		evt_obj.return_val += max(casterLevel, 1)
+		evt_obj.return_val = max(casterLevel, 1)
 		
 	return 0
 


### PR DESCRIPTION
- The written feat adds the turn undead modifier to the caster level,
  not the level of turnable monsters.
- Seems like probably a left-over += from before the check to avoid
  non-positive caster levels was added.