### PR TITLE
Stricter Concentrating status

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/sp_concentration.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/sp_concentration.py
@@ -1,0 +1,27 @@
+from templeplus.pymod import PythonModifier
+from toee import *
+import tpdp
+import tpactions
+
+def UseAct(char, args, evt_obj):
+	if tpdp.config_get_bool("StricterRulesEnforcement"):
+		if evt_obj.tb_status.hourglass_state > 1:
+			# use up a standard action
+			evt_obj.tb_status.hourglass_state = 1
+	return 0
+
+def GiveAct(char, args, evt_obj):
+	if tpdp.config_get_bool("StricterRulesEnforcement"):
+		tpactions.get_cur_seq().tb_status
+
+		if tb_status.hourglass_state == 0:
+			tb_status.hourglass_state = 2
+		elif tb_status.hourglass_state == 1:
+			tb_status.hourglass_state = 4
+
+	return 0
+
+conc = PythonModifier()
+conc.ExtendExisting('sp-Concentrating')
+conc.AddHook(ET_OnTurnBasedStatusInit, EK_NONE, UseAct, ())
+conc.AddHook(ET_OnD20ActionPerform, EK_D20A_STOP_CONCENTRATION, GiveAct, ())


### PR DESCRIPTION
I noticed you can extend existing conditions from Python, so I put together a suggestion of how to make concentration spells more accurate. The idea is that at the beginning of your turn, `sp-Concentration` removes your standard action, and if you choose the `Stop Concentration` radial, it gives it back.

There are (at least) two problems with this. The first is that `EK_D20A_STOP_CONCENTRATION` never gets dispatched. The second is that setting the `hourglass_state` in the manner I'm doing it doesn't have any effect on the real state.

I verified the latter by trying out a more complicated scheme involving a second condition that gets added by `sp-Concentration`. However, it seems like it'd be better to just be able to hook into the action perform if possible. It actually looks like that could solve both problems, even, because `Dispatch37` can carry a `tb_status`. However, it looks like it's always null in the original code.