### PR TITLE
Obscuring Mist fix

### DIFF
--- a/tpdatasrc/tpgamefiles/rules/partsys/tppartsys.tab
+++ b/tpdatasrc/tpgamefiles/rules/partsys/tppartsys.tab
@@ -44,4 +44,6 @@ sp-Small-Grease	New Emitter			perm	30						Disc		Polar		bigcircle	90	Blend	0				
 sp-Small-Grease	strike			15	100						Disc		Polar		bigcircle	90	Blend	0				0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0?360	0	20?60	0,40	0	0	0	0	0	255,0	0	0	0						10
 sp-Small-Grease	black everyonce			perm	10						Disc		Polar		bigcircle	90	Blend	0				0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0?360	0	20?60	0,40	0	0	0	0	0	255,0	0	0	0						2
 sp-Small-Grease	round the way grease			perm	30						Disc		Polar		bigcircle	90	Blend	0				0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0?360	0	60	0,10,0	0	0	0	0	0	255,0	32	0	0						10
+sp-Obscuring Mist	mist			perm	120						Sprite		Polar		fire-sprite	120	Add	0				0	0	0	0	0	0	0	40	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	10?-10	10?-10	10?-10	0?360	0	0?240	10?30	0	0	0?360	0	0	0,32,0	255	255	255						10
+sp-Obscuring Mist	New Emitter			perm	60						Sprite		Polar		fire-sprite	120	Add	0				0	0	0	0	0	0	0	40	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0?360	0	240	5?15	0	0	0?360	0	0	0,32,0	255	255	255						10
 


### PR DESCRIPTION
This adds accurate particle effects for Obscuring Mist.

The existing effects are about 5ft in radius, but the spell creates a 20ft radius effect. I'm not sure how the merging works for this file, so it might not override the old particles. However, if it isn't, it doesn't look to bad to me.

I have another suggestion for the spell which I can add to the PR. The rules file could be changed so that the targeting acts more like Bless. You can only target yourself, but you get to see the radius before the spell is cast. Right now it immediately casts as soon as you select it from the radial, because it's set up as a personal spell.

I wasn't sure what other people would think of the latter change, though, so I haven't included it yet.