### PR TITLE
Work out Mirror Image AC more properly

### DIFF
--- a/tpdatasrc/tpgamefiles/rules/d20_combat/to_hit_processing.py
+++ b/tpdatasrc/tpgamefiles/rules/d20_combat/to_hit_processing.py
@@ -56,7 +56,7 @@ def mirror_image_attack_roll(d20a):
 
     dex_ac_bonus = tgt_ac - tgt_ac_mod
 
-    size_offset = target.stat_level_get(stat_size) - 5
+    size_offset = target.stat_level_get(stat_size) - STAT_SIZE_MEDIUM
     size_bonus = 0
     if size_offset < 0:
         size_offset = - size_offset


### PR DESCRIPTION
Apparently most built-in buffs respond to `OnGetAC`, so I backed out the current Dex AC from the bonus list from calling that and manually built the bonus list for the mirror image.