### PR TITLE
Countersong

### DIFF
--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -6373,6 +6373,7 @@ int ClassAbilityCallbacks::BardicMusicBeginRound(DispatcherCallbackArgs args){
 		if (!gameSystems->GetObj().IsValidHandle(tgt)) {
 			tgt = objHndl::null;
 		}
+		auto rollResult = 0;
 		switch (bmType)
 		{
 		case BM_INSPIRE_GREATNESS:
@@ -6385,8 +6386,7 @@ int ClassAbilityCallbacks::BardicMusicBeginRound(DispatcherCallbackArgs args){
 			party.ApplyConditionAround(args.objHndCaller, 30, "Inspired_Courage", objHndl::null);
 			return 0;
 		case BM_COUNTER_SONG: 
-			auto rollResult = 0;
-			skillSys.SkillRoll(performer, SkillEnum::skill_perform, 0, &rollResult, 1);
+			skillSys.SkillRoll(args.objHndCaller, SkillEnum::skill_perform, 0, &rollResult, 1);
 			party.ApplyConditionAroundWithArgs(args.objHndCaller, 30, "Countersong", {0, rollResult, 0});
 			return 0;
 		case BM_FASCINATE: 
@@ -6576,8 +6576,7 @@ int ClassAbilityCallbacks::BardMusicActionFrame(DispatcherCallbackArgs args){
 		partsysId = gameSystems->GetParticleSys().CreateAtObj("Bardic-Inspire Courage", args.objHndCaller);
 		break;
 	case BM_COUNTER_SONG: 
-		auto rollResult = 0;
-		skillSys.SkillRoll(performer, SkillEnum::skill_perform, 0, &rollResult, 1);
+		skillSys.SkillRoll(args.objHndCaller, SkillEnum::skill_perform, 0, &rollResult, 1);
 		party.ApplyConditionAroundWithArgs(args.objHndCaller, 30, "Countersong", {0, rollResult, 0});
 		partsysId = gameSystems->GetParticleSys().CreateAtObj("Bardic-Countersong", args.objHndCaller);
 		break;

--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -6385,7 +6385,9 @@ int ClassAbilityCallbacks::BardicMusicBeginRound(DispatcherCallbackArgs args){
 			party.ApplyConditionAround(args.objHndCaller, 30, "Inspired_Courage", objHndl::null);
 			return 0;
 		case BM_COUNTER_SONG: 
-			party.ApplyConditionAround(args.objHndCaller, 30, "Countersong", objHndl::null);
+			auto rollResult = 0;
+			skillSys.SkillRoll(performer, SkillEnum::skill_perform, 0, &rollResult, 1);
+			party.ApplyConditionAroundWithArgs(args.objHndCaller, 30, "Countersong", {0, rollResult, 0});
 			return 0;
 		case BM_FASCINATE: 
 			if (tgt)
@@ -6574,7 +6576,9 @@ int ClassAbilityCallbacks::BardMusicActionFrame(DispatcherCallbackArgs args){
 		partsysId = gameSystems->GetParticleSys().CreateAtObj("Bardic-Inspire Courage", args.objHndCaller);
 		break;
 	case BM_COUNTER_SONG: 
-		party.ApplyConditionAround(args.objHndCaller, 30.0, "Countersong", objHndl::null);
+		auto rollResult = 0;
+		skillSys.SkillRoll(performer, SkillEnum::skill_perform, 0, &rollResult, 1);
+		party.ApplyConditionAroundWithArgs(args.objHndCaller, 30, "Countersong", {0, rollResult, 0});
 		partsysId = gameSystems->GetParticleSys().CreateAtObj("Bardic-Countersong", args.objHndCaller);
 		break;
 	case BM_FASCINATE: 

--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -6367,6 +6367,7 @@ int ClassAbilityCallbacks::BardicMusicBeginRound(DispatcherCallbackArgs args){
 		return 0;
 
 	auto roundsLasted = args.GetCondArg(2);
+	auto endMusic = false;
 	if (dispIo->data1 <= 1){
 		args.SetCondArg(2, roundsLasted + 1);
 		auto tgt = args.GetCondArgObjHndl(3);
@@ -6386,9 +6387,16 @@ int ClassAbilityCallbacks::BardicMusicBeginRound(DispatcherCallbackArgs args){
 			party.ApplyConditionAround(args.objHndCaller, 30, "Inspired_Courage", objHndl::null);
 			return 0;
 		case BM_COUNTER_SONG: 
-			skillSys.SkillRoll(args.objHndCaller, SkillEnum::skill_perform, 0, &rollResult, 1);
-			party.ApplyConditionAroundWithArgs(args.objHndCaller, 30, "Countersong", {0, rollResult, 0});
-			return 0;
+			if (roundsLasted+1 >= 10) {
+				// countersong only lasts up to 10 rounds
+				endMusic = true;
+				BardicMusicPlaySound(bmType, args.objHndCaller, 1);  //End sound
+			}
+			else {
+				skillSys.SkillRoll(args.objHndCaller, SkillEnum::skill_perform, 0, &rollResult, 1);
+				party.ApplyConditionAroundWithArgs(args.objHndCaller, 30, "Countersong", {0, rollResult, 0});
+			}
+			break;
 		case BM_FASCINATE: 
 			if (tgt)
 				conds.AddTo(tgt, "Fascinate", {-1, 0});
@@ -6410,7 +6418,11 @@ int ClassAbilityCallbacks::BardicMusicBeginRound(DispatcherCallbackArgs args){
 		}
 
 	} 
-	else
+	else {
+		endMusic = true;
+	}
+
+	if (endMusic)
 	{
 		args.SetCondArg(2, 0);
 		args.SetCondArg(1, 0);

--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -6616,6 +6616,7 @@ int ClassAbilityCallbacks::BardMusicActionFrame(DispatcherCallbackArgs args){
 		bardLvl += d20Sys.D20QueryPython(args.objHndCaller, "Bardic Music Bonus Levels");
 		chaScore = objects.StatLevelGet(args.objHndCaller, stat_charisma);
 		curSeq->spellPktBody.dc = 10 + bardLvl/2 + (chaScore-10)/2;
+		curSeq->spellPktBody.casterLevel = bardLvl;
 		spellSys.RegisterSpell(curSeq->spellPktBody, spellId);
 		pySpellIntegration.SpellTrigger(spellId, SpellEvent::SpellEffect);
 		break;

--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -6543,7 +6543,7 @@ int ClassAbilityCallbacks::BardMusicCheck(DispatcherCallbackArgs args){
 		return 0;
 	}
 
-	if (args.GetCondArg(0) <= 0 || bmType == BM_SUGGESTION){
+	if (args.GetCondArg(0) <= 0 && bmType != BM_SUGGESTION){
 		dispIo->returnVal = AEC_OUT_OF_CHARGES;
 	}
 

--- a/TemplePlus/damage.cpp
+++ b/TemplePlus/damage.cpp
@@ -898,19 +898,25 @@ bool Damage::SavingThrow(objHndl handle, objHndl attacker, int dc, SavingThrowTy
 		}
 	}
 
+	if (diceResult == 20){
+		// if (finalSaveThrowMod + 20 < dc)
+			return true; // natural 20 - always succeeds
+	}
+
 	auto finalSaveThrowMod = dispatch.Dispatch44FinalSaveThrow(handle, saveType, &evtObj);
 	auto histId = histSys.RollHistoryAddType3SavingThrow(handle, dc, saveType, flags, dice.ToPacked(), diceResult, &evtObj.bonlist);
 	histSys.CreateRollHistoryString(histId);
 
-	if (diceResult == 1){
+	if (finalSaveThrowMod > saveThrowMod){
+		// This branch replaces saving throws with a skill check, and the
+		// latter do not fail or succeed automatically on any roll.
+		return finalSaveThrowMod + diceResult >= dc;
+	}
+	else if (diceResult == 1){
 		// if (finalSaveThrowMod + 1 >= dc)
 			return false; // natural 1 - always fails
 	}
-	else if (diceResult == 20){
-		// if (finalSaveThrowMod + 20 < dc)
-			return true; // natural 20 - always succeeds
-	}
-	return finalSaveThrowMod + diceResult >= dc;
+	return saveThrowMod + diceResult >= dc;
 
 	// return addresses.SavingThrow(handle, attacker, dc, saveType, flags);
 }

--- a/TemplePlus/party.cpp
+++ b/TemplePlus/party.cpp
@@ -113,6 +113,14 @@ void LegacyPartySystem::GiveMoneyFromItem(const objHndl& item){
 }
 
 void LegacyPartySystem::ApplyConditionAround(const objHndl& obj, double range, const char* condName, const objHndl& obj2){
+	std::vector<int> args({ (int)obj2.GetHandleLower(), (int)obj2.GetHandleUpper() });
+	auto cond = conds.GetByName(condName);
+	for (auto i = 2u; i < cond->numArgs; i++)
+		args.push_back(0);
+	ApplyConditionAroundWithArgs(obj, range, condName, args);
+}
+
+void LegacyPartySystem::ApplyConditionAroundWithArgs(const objHndl& obj, double range, const char* condName, const vector<int>& args){
 	auto groupLen = GroupListGetLen();
 	for (auto i = 0u; i < groupLen; i++){
 		auto partyMem = GroupListGetMemberN(i);
@@ -120,10 +128,6 @@ void LegacyPartySystem::ApplyConditionAround(const objHndl& obj, double range, c
 			continue;
 		if (locSys.DistanceToObj(obj, partyMem) > range)
 			continue;
-		std::vector<int> args({ (int)obj2.GetHandleLower(), (int)obj2.GetHandleUpper() });
-		auto cond = conds.GetByName(condName);
-		for (auto i = 2u; i < cond->numArgs; i++)
-			args.push_back(0);
 		conds.AddTo(partyMem, condName, args);	
 	}
 }

--- a/TemplePlus/party.h
+++ b/TemplePlus/party.h
@@ -16,6 +16,7 @@ struct LegacyPartySystem : temple::AddressTable
 	void GiveMoneyFromItem(const objHndl& item); // increases party money from money item (gold, copper etc)
 
 	void ApplyConditionAround(const objHndl& obj, double range, const char* condName, const objHndl& obj2);
+	void ApplyConditionAroundWithArgs(const objHndl& obj, double range, const char* condName, const vector<int>& args);
 	
 	objHndl (__cdecl*GetFellowPc)(objHndl obj); // fetches a PC who is not identical to the object. For NPCs this will try to fetch their leader.
 	objHndl(__cdecl *GroupArrayMemberN)(GroupArray *, uint32_t nIdx);

--- a/TemplePlus/python/python_dispatcher.cpp
+++ b/TemplePlus/python/python_dispatcher.cpp
@@ -841,6 +841,7 @@ PYBIND11_EMBEDDED_MODULE(tpdp, m) {
 			.def_readwrite("spell_class", &SpellPacketBody::spellClass)
 			.def_readwrite("spell_id", &SpellPacketBody::spellId)
 			.def_readwrite("caster_level", &SpellPacketBody::casterLevel)
+			.def_readwrite("dc", &SpellPacketBody::dc)
 			.def_readwrite("loc", &SpellPacketBody::aoeCenter)
 			.def_readwrite("caster", &SpellPacketBody::caster)
 			.def("get_spell_casting_class", [](SpellPacketBody&pkt) {

--- a/tpdatasrc/co8infra/rules/spells/753 - Harpy Song.txt
+++ b/tpdatasrc/co8infra/rules/spells/753 - Harpy Song.txt
@@ -1,0 +1,21 @@
+School: Enchantment
+Subschool: Compulsion
+Descriptor: Mind-Affecting
+Descriptor: Sonic
+Component: V
+Component: S
+Casting Time: 1 action
+Range: Long
+Saving Throw: Willpower
+Spell Resistance: No
+Projectile: No
+flags_Target: Range
+inc_flags_Target: Other
+exc_flags_Target: Self
+exc_flags_Target: Dead
+exc_flags_Target: Undead
+exc_flags_Target: Non-critter
+exc_flags_Target: Friendly
+mode_Target: Area
+radius_Target: 90
+ai_type: ai_action_offensive

--- a/tpdatasrc/tpgamefiles/rules/spells/3003 - Bardic Fascinate.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/3003 - Bardic Fascinate.txt
@@ -1,5 +1,6 @@
 School: Enchantment
 Descriptor: Mind-Affecting
+Descriptor: Sonic
 Component: V
 Component: S
 Casting Time: 1 action

--- a/tpdatasrc/tpgamefiles/scr/Spell3000 - Bard Suggestion.py
+++ b/tpdatasrc/tpgamefiles/scr/Spell3000 - Bard Suggestion.py
@@ -20,16 +20,14 @@ def	OnSpellEffect( spell ):
 			remove_list.append(obj)
 			obj.float_text_line("Not Fascinated!", tf_red)
 			continue
-		bard_lvl = spell.caster.stat_level_get(stat_level_bard)
-		bard_level_bonus = spell.caster.d20_query("Bardic Music Bonus Levels")
-		bard_lvl += bard_level_bonus
-		bard_cha_mod = (spell.caster.stat_level_get(stat_charisma) - 10) /2
-		if obj == spell.caster or obj.saving_throw( 10 + bard_lvl/2 + bard_cha_mod, D20_Save_Will, D20STD_F_NONE, spell.caster, D20A_BARDIC_MUSIC ):
+
+		if obj == spell.caster or obj.saving_throw( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, D20A_BARDIC_MUSIC ):
 			remove_list.append(obj)
 			obj.float_mesfile_line('mes\\spell.mes', 30001)
 		else:
 			obj.d20_send_signal(S_Bardic_Music_Completed)
-			obj.condition_add_with_args("Bard Suggestion", 600 * bard_lvl, 0, spell.id)
+			obj.condition_add_with_args(
+					"Bard Suggestion", spell.duration, 0, spell.id)
 			obj.float_mesfile_line('mes\\spell.mes', 30002)
 
 	spell.target_list.remove_list(remove_list)
@@ -50,6 +48,8 @@ def OnBeginRound( spell ):
 	if obj == OBJ_HANDLE_NULL or obj == spell.caster:
 		return
 	if obj.is_unconscious():
+		remove_list.append(obj)
+	if not obj.d20_query_has_condition('Bard Suggestion'):
 		remove_list.append(obj)
 
 	spell.target_list.remove_list(remove_list)

--- a/tpdatasrc/tpgamefiles/scr/Spell3006 - Bard Suggestion Mass.py
+++ b/tpdatasrc/tpgamefiles/scr/Spell3006 - Bard Suggestion Mass.py
@@ -20,15 +20,13 @@ def	OnSpellEffect( spell ):
 			remove_list.append(obj)
 			obj.float_text_line("Not Fascinated!", tf_red)
 			continue
-		bard_lvl = spell.caster.stat_level_get(stat_level_bard)
-		bard_level_bonus = spell.caster.d20_query("Bardic Music Bonus Levels")
-		bard_lvl += bard_level_bonus
-		bard_cha_mod = (spell.caster.stat_level_get(stat_charisma) - 10) /2
-		if obj == spell.caster or obj.saving_throw( 10 + bard_lvl/2 + bard_cha_mod, D20_Save_Will, D20STD_F_NONE, spell.caster, D20A_BARDIC_MUSIC ):
+
+		if obj == spell.caster or obj.saving_throw( spell.dc, D20_Save_Will, D20STD_F_NONE, spell.caster, D20A_BARDIC_MUSIC ):
 			remove_list.append(obj)
 			obj.float_mesfile_line('mes\\spell.mes', 30001)
 		else:
-			obj.condition_add_with_args("Bard Suggestion", 600 * bard_lvl, 0, spell.id)
+			obj.condition_add_with_args(
+					"Bard Suggestion", spell.duration, 0, spell.id)
 			obj.d20_send_signal(S_Action_Recipient)
 			obj.float_mesfile_line('mes\\spell.mes', 30002)
 
@@ -49,6 +47,8 @@ def OnBeginRound( spell ):
 
 	if obj == OBJ_HANDLE_NULL or obj == spell.caster:
 		return
+	if not obj.d20_query_has_condition('Bard Suggestion'):
+		remove_list.append(obj)
 
 	if obj.is_unconscious():
 		remove_list.append(obj)

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/captivating_song.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/captivating_song.py
@@ -1,0 +1,31 @@
+from templeplus.pymod import PythonModifier
+from toee import *
+import tpdp
+
+# A special removal function beyond the spell_utils one because this
+# condition is a bit more complicated.
+def CountersongSpecial(char, args, evt_obj):
+	if not evt_obj.is_modifier('Countersong'): return 0
+	spell_id = args.get_arg(0)
+	packet = tpdp.SpellPacket(spell_id)
+
+	if packet.dc <= evt_obj.arg2:
+		char.d20_send_signal('End Captivating Song')
+		args.remove_spell()
+		args.remove_spell_mod()
+
+	return 0
+
+csong = PythonModifier()
+csong.ExtendExisting('Captivating Song')
+csong.AddHook(ET_OnConditionAddPre, EK_NONE, CountersongSpecial, ())
+
+# End Captivated condition when Captivating Song is ended in the above
+# way.
+def End(char, args, evt_obj):
+	args.condition_remove()
+	return 0
+
+capt = PythonModifier()
+capt.ExtendExisting('Captivated')
+capt.AddHook(ET_OnD20PythonSignal, 'End Captivating Song', End, ())

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/countersong.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/countersong.py
@@ -1,0 +1,12 @@
+from templeplus.pymod import PythonModifier
+from toee import *
+import tpdp
+
+def Remove(char, args, evt_obj):
+	if evt_obj.is_modifier('Countersong'):
+		args.condition_remove()
+	return 0
+
+countersong = PythonModifier()
+countersong.ExtendExisting('Countersong')
+countersong.AddHook(ET_OnConditionAddPre, EK_NONE, Remove, ())

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/countersong.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/countersong.py
@@ -7,6 +7,21 @@ def Remove(char, args, evt_obj):
 		args.condition_remove()
 	return 0
 
+# built-in hook only checks for Sonic descriptor
+def Lang(char, args, evt_obj):
+	lang = 1 << (D20STD_F_SPELL_DESCRIPTOR_LANGUAGE_DEPENDENT-1)
+	sonic = 1 << (D20S%D_F_SPELL_DESCRIPTOR_SONIC-1)
+
+	if (evt_obj.flags & lang) and not (evt_obj.flags & sonic):
+		perform = args.get_arg(1)
+		save_bonus = evt_obj.bonus_list.get_sum()
+		delta = perform - save_bonus - evt_obj.roll_result
+		if delta > 0:
+			evt_obj.bonus_list.add(delta, 0, 192)
+
+	return 0
+
 countersong = PythonModifier()
 countersong.ExtendExisting('Countersong')
 countersong.AddHook(ET_OnConditionAddPre, EK_NONE, Remove, ())
+countersong.AddHook(ET_OnCountersongSaveThrow, EK_NONE, Lang, ())


### PR DESCRIPTION
Working on countersong. Pretty sure it didn't actually do anything before. The `OnCountersongSaveThrow` handler checks an argument for the replacement saving throw, but it was always set to 0.

There are other issues as well, but without fixing that part first, nothing else can work.

One question I have is: the way Countersong is described is that you can use the bard's Perform check instead of a saving throw. The way the _code_ is written is to use the perform check to construct a bonus to the save, and still fail on a 1. Skill checks don't automatically fail on a 1, though. So, should I leave it as-is; a variable save bonus? Or should I modify it to act like it's actually the bard countering with a skill roll?

I don't think preserving vanilla behavior is really a factor, because the 0 argument thing means that it would never have done anything anyway (no DC 0 checks), so the existing behavior is hypothetical only.