### PR TITLE
Fix mesfiles for Disrupting Weapon

### DIFF
--- a/tpdatasrc/tpgamefiles/mes/spell_ext.mes
+++ b/tpdatasrc/tpgamefiles/mes/spell_ext.mes
@@ -1,9 +1,9 @@
-{590}{Disrupting Weapon}
 {1000}{Moment of Prescience}
 {1001}{Touch of Fatigue}
 {1002}{Ray of Exhaustion}
 {1003}{Waves of Fatigue}
 {1004}{Waves of Exhaustion}
+{1300}{Disrupting Weapon}
 {3000}{Bardic Suggestion}
 {3003}{Fascinate}
 {3006}{Mass Suggestion}
@@ -11,8 +11,6 @@
 
 {5150} Energy Drain {[Necromancy] Ranged touch attack inflicts 2d4 negative levels.}
 {5151} Enervation {[Necromancy] Ranged touch attack inflicts 1d4 negative levels.}
-{5590} Disrupting Weapon {[Transmutation] Makes a melee weapon deadly to
-undead.}
 {5309} Mind Fog {[Enchantment] Subjects in fog get -10 to Wisdom and Will checks.}
 {5522}{[Evocation] Creates a 10' wide curtain of fire that deals an initial 2d4 fire damage and 2d6 +1/lvl to creatures passing through it.}
 {5186}{[Divination] This spell grants you a powerful sixth sense in relation to yourself or another.}
@@ -22,6 +20,7 @@ undead.}
 {6002}{[Necromancy] A black ray projects from your pointing finger. You must succeed on a ranged touch attack with the ray to strike a target.  The subject is immediately exhausted for the spell's duration.  A successful Fortitude save means the creature is only fatigued.  A character that is already fatigued instead becomes exhausted.  This spell has no effect on a creature that is already exhausted.  Unlike normal exhaustion or fatigue, the effect ends as soon as the spell's duration expires.}
 {6003}{[Necromancy] Waves of negative energy render all living creatures in the spell's area fatigued. This spell has no effect on a creature that is already fatigued.}
 {6004}{[Necromancy] Waves of negative energy cause all living creatures in the spell's area to become exhausted. This spell has no effect on a creature that is already exhausted. }
+{6300} Disrupting Weapon {[Transmutation] Makes a melee weapon deadly to undead.}
 {8000}Bardic Suggestion{Bardic Suggestion (INTERNAL)}
 
 {90000}{Captivated!}

--- a/tpdatasrc/tpgamefiles/mes/spell_long_descriptions.mes
+++ b/tpdatasrc/tpgamefiles/mes/spell_long_descriptions.mes
@@ -2077,12 +2077,6 @@ Range:               Medium,  100  feet  + 10/level
 Target:            creatures, no more than 30' apart
 Duration:      1  round/level,    Save: Will  negates,    SR: Y}
 {5589}{}
-{5590} Disrupting Weapon {Makes a weapon destroy undead on hit unless they make a will save.
-
-Casting:         1  std action   [Transmutation, V,S]
-Range:               Touch
-Target:            One melee weapon
-Duration:      1 round/level,     Save: Will negates}
 {5591}{}
 {5592}{}
 {5593}{}
@@ -2194,3 +2188,9 @@ Casting:         1  std action   [Necromancy, V,S]
 Range:               60 ft.
 Area:                   Cone-shaped burst
 Duration:      Instantaneous,    Save: No,    SR: Yes}
+{6300} Disrupting Weapon {Makes a weapon destroy undead on hit unless they make a will save.
+
+Casting:         1  std action   [Transmutation, V,S]
+Range:               Touch
+Target:            One melee weapon
+Duration:      1 round/level,     Save: Will negates}

--- a/tpdatasrc/tpgamefiles/rules/spell_enums/dolio_spell_enum.mes
+++ b/tpdatasrc/tpgamefiles/rules/spell_enums/dolio_spell_enum.mes
@@ -1,6 +1,9 @@
 
+{1300} {Disrupting Weapon}
 {1311} {Greater Mirror Image}
 
+{6300} {Disrupting Weapon}
 {6311} {Greater Mirror Image}
 
+{21300} {TAG_SPELLS_DISRUPTING_WEAPON}
 {21311} {TAG_SPELLS_GREATER_MIRROR_IMAGE}

--- a/tpdatasrc/tpgamefiles/sound/user_sounds/tpsounds.mes
+++ b/tpdatasrc/tpgamefiles/sound/user_sounds/tpsounds.mes
@@ -42,17 +42,6 @@
 {9006}{} // spell projectile in-flight
 {9007}{spells\sp_enervation_hit.wav} // spell hit
 
-// 590: Disrupting Weapon
-{17800} {} // begin
-{17801} {} // end
-{17802} {spells\sp_bless_weapon.wav} // effect
-{17803} {} // new round
-{17804} {} // projectile begin
-{17805} {} // projectile end
-{17806} {} // projectile in flight
-{17807} {} // hit
-{17808} {} // struck
-
 // [1000] *[Moment of Prescience]
 {26000}{} // spell begin
 {26001}{spells\sp_arcane_eye.WAV} // spell end
@@ -107,4 +96,15 @@
 {26086}{} // spell projectile in-flight
 {26087}{} // spell hit
 {26088}{} // spell struck
+
+// [1300]: Disrupting Weapon
+{32000} {} // begin
+{32001} {} // end
+{32002} {spells\sp_bless_weapon.wav} // effect
+{32003} {} // new round
+{32004} {} // projectile begin
+{32005} {} // projectile end
+{32006} {} // projectile in flight
+{32007} {} // hit
+{32008} {} // struck
 


### PR DESCRIPTION
Some weren't updated when the enum changed from 590 to 1300, and the information in one was just completely missing.