### PR TITLE
Fix indexing error in RemoveWielderCond

### DIFF
--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -554,7 +554,7 @@ void InventorySystem::RemoveWielderCond(objHndl item, uint32_t condId, int spell
 				itemObj->RemoveInt32(obj_f_item_pad_wielder_argument_array, j);
 			return;
 		}
-		argIdx += wCond->numArgs;
+		argIdx += conds.GetById(wCondId)->numArgs;
 	}
 
 }


### PR DESCRIPTION
The loop was using the condition being searched for to bump the argument index, not the condition found.