### PR TITLE
Handle item conditions in remove spell

### DIFF
--- a/TemplePlus/spell_condition.cpp
+++ b/TemplePlus/spell_condition.cpp
@@ -179,7 +179,7 @@ public:
 				icond = conds.GetByName("Weapon Enhancement Bonus");
 				break;
 			case 261: // Keen Edge
-				icond = conds.getByName("Weapon Keen");
+				icond = conds.GetByName("Weapon Keen");
 				break;
 			case 291: // Magic Vestment
 				icond = conds.GetByName("Armor Enhancement Bonus");


### PR DESCRIPTION
Attempting to fix the issue where spells like Magic Weapon remove item wielder conditions in most-recently-added order, rather than actually looking for the right condition.