### PR TITLE
Fix some weapon animation bugs caused by the 2-handed patch

### DIFF
--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -1052,10 +1052,11 @@ gfx::EncodedAnimId LegacyCritterSystem::GetWeaponAnim(objHndl wielder, objHndl w
 	gfx::WeaponAnimType sAnimId = gfx::WeaponAnimType::Unarmed;
 
 	bool mainTwoHand = false;
+	bool special = WeaponAnim::Special1 <= animId && animId <= WeaponAnim::Special3;
 
 	if (wpn) {
 		auto primaryType = objects.GetType(wpn);
-		mainTwoHand = inventory.IsWieldedTwoHanded(wpn, wielder);
+		mainTwoHand = inventory.IsWieldedTwoHanded(wpn, wielder, special);
 		if (ObjectType::obj_t_weapon == primaryType) {
 			pAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(wpn, wielder);
 		} else if (ObjectType::obj_t_armor == primaryType) {

--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -1052,7 +1052,7 @@ gfx::EncodedAnimId LegacyCritterSystem::GetWeaponAnim(objHndl wielder, objHndl w
 	gfx::WeaponAnimType sAnimId = gfx::WeaponAnimType::Unarmed;
 
 	bool mainTwoHand = false;
-	bool special = WeaponAnim::Special1 <= animId && animId <= WeaponAnim::Special3;
+	bool special = gfx::WeaponAnim::Special1 <= animId && animId <= gfx::WeaponAnim::Special3;
 
 	if (wpn) {
 		auto primaryType = objects.GetType(wpn);

--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -1058,7 +1058,7 @@ gfx::EncodedAnimId LegacyCritterSystem::GetWeaponAnim(objHndl wielder, objHndl w
 		auto primaryType = objects.GetType(wpn);
 		mainTwoHand = inventory.IsWieldedTwoHanded(wpn, wielder, special);
 		if (ObjectType::obj_t_weapon == primaryType) {
-			pAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(wpn, wielder);
+			pAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(wpn, wielder, special);
 		} else if (ObjectType::obj_t_armor == primaryType) {
 			pAnimId = gfx::WeaponAnimType::Shield;
 		}
@@ -1070,7 +1070,7 @@ gfx::EncodedAnimId LegacyCritterSystem::GetWeaponAnim(objHndl wielder, objHndl w
 	if (scnd && !mainTwoHand) {
 		auto secondaryType = objects.GetType(scnd);
 		if (ObjectType::obj_t_weapon == secondaryType) {
-			sAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(scnd, wielder);
+			sAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(scnd, wielder, special);
 		} else if (ObjectType::obj_t_armor == secondaryType) {
 			sAnimId = gfx::WeaponAnimType::Shield;
 		}

--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -1051,19 +1051,22 @@ gfx::EncodedAnimId LegacyCritterSystem::GetWeaponAnim(objHndl wielder, objHndl w
 	gfx::WeaponAnimType pAnimId = gfx::WeaponAnimType::Unarmed;
 	gfx::WeaponAnimType sAnimId = gfx::WeaponAnimType::Unarmed;
 
+	bool mainTwoHand = false;
+
 	if (wpn) {
 		auto primaryType = objects.GetType(wpn);
+		mainTwoHand = inventory.IsWieldedTwoHanded(wpn, wielder);
 		if (ObjectType::obj_t_weapon == primaryType) {
 			pAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(wpn, wielder);
 		} else if (ObjectType::obj_t_armor == primaryType) {
 			pAnimId = gfx::WeaponAnimType::Shield;
 		}
-		if (inventory.IsWieldedTwoHanded(wpn, wielder)) {
+		if (mainTwoHand) {
 			sAnimId = pAnimId;
 		}
 	}
 
-	if (scnd) {
+	if (scnd && !mainTwoHand) {
 		auto secondaryType = objects.GetType(scnd);
 		if (ObjectType::obj_t_weapon == secondaryType) {
 			sAnimId = (gfx::WeaponAnimType)inventory.GetWeaponAnimId(scnd, wielder);

--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -1521,7 +1521,7 @@ int32_t InventorySystem::GetCoinWorth(int32_t coinType){
 // 0: light weapon
 // 1: 1-handed weapon
 // 2: 2-handed weapon
-// 3: bastard/dwarf waraxe 2-handed
+// 3: bastard sword/dwarf waraxe too big to wield
 // 4: null weapon
 int InventorySystem::GetWieldType(objHndl wielder, objHndl item, bool regardEnlargement) const
 {

--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -1604,7 +1604,7 @@ int InventorySystem::GetWieldType(objHndl wielder, objHndl item, bool regardEnla
 	return 2 * (wielderSize <= 5) + 1;	
 }
 
-bool InventorySystem::IsWieldedTwoHanded(objHndl weapon, objHndl wielder){
+bool InventorySystem::IsWieldedTwoHanded(objHndl weapon, objHndl wielder, bool special){
 	if (!weapon) return false;
 
 	auto weapObj = gameSystems->GetObj().GetObject(weapon);
@@ -1634,7 +1634,7 @@ bool InventorySystem::IsWieldedTwoHanded(objHndl weapon, objHndl wielder){
 	// the wield type if the weapon is not enlarged along with the critter
 	auto wieldTypeMod = GetWieldType(wielder, weapon, false);
 
-	bool isTwohandedWieldable = !hasInterferingOffhand;
+	bool isTwohandedWieldable = !hasInterferingOffhand && !special;
 
 	switch (wieldType)
 	{
@@ -1684,13 +1684,12 @@ bool InventorySystem::IsWieldedTwoHanded(objHndl weapon, objHndl wielder){
 
 
 
-gfx::WeaponAnimType InventorySystem::GetWeaponAnimId(objHndl item, objHndl wielder){
+gfx::WeaponAnimType InventorySystem::GetWeaponAnimId(objHndl item, objHndl wielder, bool special){
 	auto wieldType = GetWieldType(wielder, item, false);
 	WeaponTypes wtype = (WeaponTypes)objects.getInt32(item, obj_f_weapon_type);
 
 	if (wieldType == 4) return gfx::WeaponAnimType::Unarmed;
-	// if (wieldType > 2) return gfx::WeaponAnimType::Unarmed;
-	if (IsWieldedTwoHanded(item, wielder)) {
+	if (IsWieldedTwoHanded(item, wielder, special)) {
 		switch (wtype)
 		{
 		// piercing weapons

--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -1683,7 +1683,8 @@ gfx::WeaponAnimType InventorySystem::GetWeaponAnimId(objHndl item, objHndl wield
 	auto wieldType = GetWieldType(wielder, item, false);
 	WeaponTypes wtype = (WeaponTypes)objects.getInt32(item, obj_f_weapon_type);
 
-	if (wieldType > 2) return gfx::WeaponAnimType::Unarmed;
+	if (wieldType == 4) return gfx::WeaponAnimType::Unarmed;
+	// if (wieldType > 2) return gfx::WeaponAnimType::Unarmed;
 	if (IsWieldedTwoHanded(item, wielder)) {
 		switch (wtype)
 		{

--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -1518,6 +1518,11 @@ int32_t InventorySystem::GetCoinWorth(int32_t coinType){
 	return 0u;
 }
 
+// 0: light weapon
+// 1: 1-handed weapon
+// 2: 2-handed weapon
+// 3: bastard/dwarf waraxe 2-handed
+// 4: null weapon
 int InventorySystem::GetWieldType(objHndl wielder, objHndl item, bool regardEnlargement) const
 {
 	if (!regardEnlargement)

--- a/TemplePlus/inventory.h
+++ b/TemplePlus/inventory.h
@@ -200,8 +200,12 @@ struct InventorySystem : temple::AddressTable
 		   (so it will actually use the base critter size to determine wield type)
 	*/
 	int GetWieldType(objHndl wielder, objHndl item, bool regardEnlargement = false) const;
-	bool IsWieldedTwoHanded(objHndl item, objHndl wielder);
-	gfx::WeaponAnimType GetWeaponAnimId(objHndl item, objHndl wielder);
+	bool IsWieldedTwoHanded(objHndl item, objHndl wielder, bool special = false);
+	/*
+	 * Special indicates that the motivation is a SpecialN attack, e.g. Brother
+	 * Smyth's forge animation.
+	 */
+	gfx::WeaponAnimType GetWeaponAnimId(objHndl item, objHndl wielder, bool special = false);
 	static obj_f GetInventoryListField(objHndl objHnd);
 	static obj_f GetInventoryNumField(objHndl objHnd);
 	/*


### PR DESCRIPTION
This PR fixes two bugs introduced by the previous weapon animation patch.

1. Brother Smyth wasn't properly doing his forge animation, because he's wielding a war hammer. The fix to this is to prefer 1-handing/the old behavior for `WeaponAnim::SpecialN`.
2. Wearing a buckler while 2-handing weapons was giving weird results. It looked like you were just punching people while holding the weapon. Here the problem seems to be that packing an off-hand animation (for the buckler) doesn't work for 2-handers. You need to have the 2-handed animation packed in both spots. So I skip the off-hand logic completely if the main hand is being 2-handed.

I also did a little work to figure out what a `3` result from `GetWieldType` is supposed to mean, and put it in a comment specifying its results.