### PR TITLE
Fix crash from shield bash and mirror image

### DIFF
--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -1824,10 +1824,10 @@ int ArmorCritMultiplier(DispatcherCallbackArgs args)
 
 int ShieldBashProficiencyPenalty(DispatcherCallbackArgs args)
 {
+	auto dispIo = dispatch.DispIoCheckIoType5(args.dispIO);
 	auto attacker = dispIo->attackPacket.attacker;
 	if (!attacker) return 0;
 
-	auto dispIo = dispatch.DispIoCheckIoType5(args.dispIO);
 	auto invIdx = args.GetCondArg(2);
 	auto shield = inventory.GetItemAtInvIdx(attacker, invIdx);
 

--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -1824,9 +1824,11 @@ int ArmorCritMultiplier(DispatcherCallbackArgs args)
 
 int ShieldBashProficiencyPenalty(DispatcherCallbackArgs args)
 {
+	auto attacker = dispIo->attackPacket.attacker;
+	if (!attacker) return 0;
+
 	auto dispIo = dispatch.DispIoCheckIoType5(args.dispIO);
 	auto invIdx = args.GetCondArg(2);
-	auto attacker = dispIo->attackPacket.attacker;
 	auto shield = inventory.GetItemAtInvIdx(attacker, invIdx);
 
 	if (dispIo->attackPacket.weaponUsed != shield) return 0;

--- a/tpdatasrc/tpgamefiles/rules/d20_combat/to_hit_processing.py
+++ b/tpdatasrc/tpgamefiles/rules/d20_combat/to_hit_processing.py
@@ -73,6 +73,7 @@ def mirror_image_attack_roll(d20a):
 
     #Performer to Hit Bonus
     to_hit = tpdp.EventObjAttack()
+    to_hit.attack_packet.attacker = performer
     to_hit.dispatch(performer, OBJ_HANDLE_NULL, ET_OnToHitBonus2, EK_NONE)
 
     to_hit_dice = dice_new("1d20")


### PR DESCRIPTION
This fixes a crash I noticed when you try to attack a mirror image while holding a shield with the new shield bash stuff. The mirror image logic ran a to hit query with no attacker/defender set, and the shield bash stuff was expecting that the attacker would be there.

I double fixed it, just to be thorough. The shield bash query checks to make sure the attacker is actually set, and the mirror image code now sets the attacker.

Hopefully I submitted this against the right branch. I noticed you'd been switching them to this one. Let me know if I need to redo against master.