### PR TITLE
Fix double stacking NPC save bonus

### DIFF
--- a/TemplePlus/damage.cpp
+++ b/TemplePlus/damage.cpp
@@ -159,7 +159,7 @@ class DamageHooks: TempleFix
 			return damage.DealAttackDamage(attacker, tgt, d20Data, flags, actionType);
 		});
 
-		replaceFunction<bool(__cdecl)(objHnd, objHndl, int, int, int)>(0x100B4F20, [](objHndl tgt, objHndl atk, int dc, int saveType, int flags) {
+		replaceFunction<bool(__cdecl)(objHndl, objHndl, int, int, int)>(0x100B4F20, [](objHndl tgt, objHndl atk, int dc, int saveType, int flags) {
 			return damage.SavingThrow(tgt, atk, dc, saveType, flags);
 		});
 	}

--- a/TemplePlus/damage.cpp
+++ b/TemplePlus/damage.cpp
@@ -160,7 +160,7 @@ class DamageHooks: TempleFix
 		});
 
 		replaceFunction<bool(__cdecl)(objHndl, objHndl, int, int, int)>(0x100B4F20, [](objHndl tgt, objHndl atk, int dc, int saveType, int flags) {
-			return damage.SavingThrow(tgt, atk, dc, saveType, flags);
+			return damage.SavingThrow(tgt, atk, dc, static_cast<SavingThrowType>(saveType), flags);
 		});
 	}
 } damageHooks;

--- a/TemplePlus/damage.cpp
+++ b/TemplePlus/damage.cpp
@@ -73,8 +73,6 @@ static struct DamageAddresses : temple::AddressTable {
 	int (__cdecl*HealSubdual)(objHndl target, int amount);
 
 	int (__cdecl*DoSpellDamage)(objHndl victim, objHndl attacker, uint32_t dmgDice, DamageType type, int attackPowerType, int reduction, int damageDescMesKey, int actionType, int spellId, int flags);
-
-	bool (__cdecl *SavingThrow)(objHndl obj, objHndl attacker, int dc, SavingThrowType type, int flags);
 	
 	bool (__cdecl *SavingThrowSpell)(objHndl obj, objHndl attacker, int dc, SavingThrowType type, int flags, int spellId);
 
@@ -110,7 +108,6 @@ static struct DamageAddresses : temple::AddressTable {
 		rebase(HealSpell, 0x100B81D0);
 		rebase(DoSpellDamage, 0x100B7F80);
 		rebase(HealSubdual, 0x100B9030);
-		rebase(SavingThrow, 0x100B4F20);
 		rebase(SavingThrowSpell, 0x100B83C0);
 		rebase(ReflexSaveAndDamage, 0x100B9500);
 
@@ -160,6 +157,10 @@ class DamageHooks: TempleFix
 
 		replaceFunction<int(__cdecl)(objHndl, objHndl, int, D20CAF, D20ActionType)>(0x100B7950, [](objHndl attacker, objHndl tgt, int d20Data, D20CAF flags, D20ActionType actionType) {
 			return damage.DealAttackDamage(attacker, tgt, d20Data, flags, actionType);
+		});
+
+		replaceFunction<bool(__cdecl)(objHnd, objHndl, int, int, int)>(0x100B4F20, [](objHndl tgt, objHndl atk, int dc, int saveType, int flags) {
+			return damage.SavingThrow(tgt, atk, dc, saveType, flags);
 		});
 	}
 } damageHooks;
@@ -891,8 +892,6 @@ bool Damage::SavingThrow(objHndl handle, objHndl attacker, int dc, SavingThrowTy
 			return false; // natural 1 - always fails
 	}
 	return saveThrowMod + diceResult >= dc;
-
-	// return addresses.SavingThrow(handle, attacker, dc, saveType, flags);
 }
 
 bool Damage::SavingThrowSpell(objHndl obj, objHndl attacker, int dc, SavingThrowType type, int flags, int spellId) {


### PR DESCRIPTION
Here's one more quick fix.

At some point in the past, the code for NPC saves from their racial hit dice was moved into the global saving throw handler so that they'd show up on character sheets. However, the original `SavingThrow` function was just referenced with `rebase`. This meant that anything that performed a `SavingThrow` call in the original code would get a double bonus (because the racial save is bonus type 0). Examples are stinking cloud and web AoE hits.

This eliminates the `rebase` `SavingThrow` and instead does `replaceFunction` with the reimplementation. Nothing was actually calling the former anymore (it looks like the replacing function was at one point, but it was commented).