### PR TITLE
Guard coup de grace save under strict rules

### DIFF
--- a/TemplePlus/d20.cpp
+++ b/TemplePlus/d20.cpp
@@ -2680,8 +2680,9 @@ BOOL D20ActionCallbacks::ActionFrameCoupDeGrace(D20Actn* d20a) {
 		return 0;
 
 	auto dc = 10 + dmg;
+	bool strict = config.stricterRulesEnforcement;
 
-	if (damage.SavingThrow(target, performer, dc, SavingThrowType::Fortitude, D20STF_NONE))
+	if (strict && damage.SavingThrow(target, performer, dc, SavingThrowType::Fortitude, D20STF_NONE))
 		return 0;
 
 	auto leader = party.GetConsciousPartyLeader();


### PR DESCRIPTION
This makes the saving throw for coup de grace only happen under strict rules.

Under original game rules they automatically kill the target as long as you do any damage.