### PR TITLE
Magic Missiles + Mirror Image

### DIFF
--- a/TemplePlus/python/python_dice.cpp
+++ b/TemplePlus/python/python_dice.cpp
@@ -78,7 +78,7 @@ int PyDice_Init(PyObject *obj, PyObject *args, PyObject *kwds) {
 	} else {
 		self->bonus = 0; // Initialize since it's optional
 		// Form: PyDice(1, 2[, 3]) for 1d2+3 etc.
-		if (!PyArg_ParseTuple(args, "ii|:PyDice", &self->number, &self->size, &self->bonus)) {
+		if (!PyArg_ParseTuple(args, "ii|i:PyDice", &self->number, &self->size, &self->bonus)) {
 			return -1;
 		}
 	}

--- a/tpdatasrc/co8infra/scr/Spell288 - Magic Missile.py
+++ b/tpdatasrc/co8infra/scr/Spell288 - Magic Missile.py
@@ -1,4 +1,5 @@
 from toee import *
+import tpdp
 
 def OnBeginSpellCast( spell ):
 	print "Magic Missile OnBeginSpellCast"
@@ -13,6 +14,47 @@ def OnBeginSpellCast( spell ):
 def OnSpellEffect( spell ):
 	print "Magic Missile OnSpellEffect"
 
+	# only enable mirror image behavior in strict rules
+	if not tpdp.config_get_bool('stricterRulesEnforcement'): return
+
+	# Calculate which missiles hit mirror images instead of the actual target.
+	#
+	# This needs to be calculated ahead of time if we want to simulate picking
+	# targets _before_ we know which is the real one, for situations where there
+	# are more missiles than (real and fake) targets.
+	offsets = []
+	seen = []
+	hits = [0,0,0,0,0]
+	hi = -1
+	for target_item in spell.target_list:
+		target = target_item.obj
+		hi += 1
+
+		# handles can't be hashed, so we need to do something like this
+		if target in seen:
+			ix = seen.index(target)
+			# if the same spell target occurs more than once, assume we're targeting
+			# as many distinct copies if possible
+			off, copies = offsets[ix]
+			offsets[ix] = (off+1, copies)
+
+			if off % copies > 0: hits[hi] = 1
+		else:
+			mirrors = target.d20_query(Q_Critter_Has_Mirror_Image)
+			# no mirrors, always hit
+			if mirrors <= 0: continue
+
+			copies = mirrors+1
+			off = dice_new(1, copies, -1).roll()
+
+			# save the _next_ offset
+			offsets.append((off+1, copies))
+			seen.append(target)
+
+			if off > 0: hits[hi] = 1
+
+	h1, h2, h3, h4, h5 = hits
+	spell.caster.condition_add_with_args('Magic Missile Mirror', spell.id, h1, h2, h3, h4, h5)
 
 def OnBeginRound( spell ):
 	print "Magic Missile OnBeginRound"
@@ -29,21 +71,30 @@ def OnEndProjectile( spell, projectile, index_of_target ):
 
 	game.particles_end( projectile.obj_get_int( obj_f_projectile_part_sys_id ) )
 
-	target = spell.target_list[ index_of_target ]
+	target_item = spell.target_list[ index_of_target ]
+	target = target_item.obj
 
-	damage_dice = dice_new( '1d4' )
-	damage_dice.bonus = 1
+	hit_mirror = spell.caster.d20_query_with_data('Missile Mirror Hit', spell.id, index_of_target + 1)
 
-	target_item_obj = target.obj
-	if (not spell.caster in game.party[0].group_list() ) and target_item_obj.d20_query(Q_Critter_Is_Charmed ) :
-		# NPC enemy is trying to cast on a charmed target - this is mostly meant for the Cult of the Siren encounter
-		target_item_obj = party_closest( spell.caster, conscious_only= 1, mode_select= 1, exclude_warded= 1, exclude_charmed = 1) # select nearest conscious PC instead, who isn't already charmed
-		if target_item_obj == OBJ_HANDLE_NULL:
-			target_item_obj = target.obj
+	if hit_mirror > 0:
+		if target.d20_query(Q_Critter_Has_Mirror_Image) > 0:
+			mirror_id = target.d20_query_get_data(Q_Critter_Has_Mirror_Image, 0)
+			target.d20_send_signal(S_Spell_Mirror_Image_Struck, mirror_id, 0)
+			target.float_mesfile_line('mes\\combat.mes', 109)
+			game.create_history_from_pattern(10, spell.caster, target)
+	else: # normal damage
+		damage_dice = dice_new(1,4,1)
+		is_enemy = not spell.caster in game.party[0].group_list()
+		target_charmed = target.d20_query(Q_Critter_Is_Charmed)
+		if is_enemy and target_charmed:
+			# NPC enemy is trying to cast on a charmed target - this is mostly meant for the Cult of the Siren encounter
+			target = party_closest( spell.caster, conscious_only= 1, mode_select= 1, exclude_warded= 1, exclude_charmed = 1) # select nearest conscious PC instead, who isn't already charmed
+			if target == OBJ_HANDLE_NULL:
+				target = target_item.obj
 
-	# always hits
-	target_item_obj.condition_add_with_args( 'sp-Magic Missile', spell.id, spell.duration, damage_dice.roll() )
-	target.partsys_id = game.particles( 'sp-magic missle-hit', target_item_obj )
+		# always hits
+		target.condition_add_with_args('sp-Magic Missile', spell.id, spell.duration, damage_dice.roll())
+		target_item.partsys_id = game.particles('sp-magic missle-hit', target)
 
 	# special scripting for NPCs no longer necessary - NPCs will launch multiple projectiles now
 
@@ -51,10 +102,11 @@ def OnEndProjectile( spell, projectile, index_of_target ):
 	spell.num_of_projectiles -= 1
 
 	if spell.num_of_projectiles == 0:
-##		loc = target.obj.location
-##		target.obj.destroy()
+##		loc = target.location
+##		target.destroy()
 ##		mxcr = game.obj_create( 12021, loc )
 ##		game.global_vars[30] = game.global_vars[30] + 1
+		spell.caster.d20_send_signal(S_Spell_End, spell.id)
 		spell.spell_end( spell.id, 1 )
 
 def OnEndSpellCast( spell ):

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/sp_magic_missile.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/sp_magic_missile.py
@@ -1,0 +1,27 @@
+from templeplus.pymod import PythonModifier
+from toee import *
+import tpdp
+from utilities import *
+from spell_utils import *
+
+print "registering sp_magic_missile"
+
+def GetStatus(caster, args, evt_obj):
+	id = evt_obj.data1
+	if id != args.get_arg(0): return 0
+
+	ix = evt_obj.data2
+	if ix < 1 or 5 < ix: return 0
+
+	evt_obj.return_val = args.get_arg(ix)
+	return 0
+
+def Remove(caster, args, evt_obj):
+	args.condition_remove()
+	return 0
+
+# 0: spell_id
+# 1-5: mirror hit projectile 1-5
+mmm = PythonModifier('Magic Missile Mirror', 6)
+mmm.AddHook(ET_OnD20PythonQuery, 'Missile Mirror Hit', GetStatus, ())
+mmm.AddHook(ET_OnD20Signal, EK_S_Spell_End, Remove, ())


### PR DESCRIPTION
Here's another quick one.

With strict rules enabled, it makes Mirror Image interact with Magic Missile. Essentially, all the images are valid targets, so the caster of magic missile has to randomly determine their targets just like other attackers would.

I made the simplifying assumption that if you target someone multiple times, and they have mirror images, you'd spread out the choices. So, each missile will target a different copy if possible, one of which may be the real creature. If you target with _more_ missiles than there are copies, it distributes them as evenly as possible, and it's possible some of the missiles will have no effect, because they both targeted the same mirror image.

This isn't a strict buff or nerf. It means that Mirror Image can provide protection from Magic Missile. But it also means that Magic Missile can shred off up to 5 images in one go.

The lack of interaction was Atari bug 161.

I didn't do KotB magic missile because the script wasn't in there already. Should I copy it over from the Co8 directory? It kind of looks like the one in the module is unmodified from ToEE (so, has a bunch of special cases for particular NPCs that I guess are no longer necessary in T+, and might not even exist in KotB).