### PR TITLE
Update char_class_utils.py fixed a "elif" when it should be "if"

### DIFF
--- a/tpdatasrc/tpgamefiles/rules/char_class/char_class_utils.py
+++ b/tpdatasrc/tpgamefiles/rules/char_class/char_class_utils.py
@@ -85,7 +85,7 @@ def GetSpellsKnownAddedCount( spells_known, spellListLvl, spellLvl):
 				prevNumKnown = q[spellLvl]
 			else:
 				prevNumKnown = 0
-		elif (p > highestEntry and p < spellListLvl):
+		if (p > highestEntry and p < spellListLvl):
 			highestEntry = p
 	# print "newNumKnown is " + str(newNumKnown) + "prevNumKnown is: " + str(prevNumKnown)
 	if (newNumKnown == -999):


### PR DESCRIPTION
        spells_known = {
            1: [6, 3, 2],  # at first level we know 6 cantrips, 3 first and 2 second level spells
            2: [6, 5, 4, 1], # at second level we know 6 cantrips, 5 first, 4 second and 1 third level spell
        }
        METHOD FAILS
        caster_level=3, spell_level=1  ==> 3 but should be 2
        caster_level=3, spell_level=3  ==> 0 but should be 1