### PR TITLE
Ultimate Magus fix for widen spell

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/ultimate_magus.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/ultimate_magus.py
@@ -299,6 +299,8 @@ def AugmentCastingRadialMenuEntry(attachee, args, evt_obj):
 					minLevel = 4
 				elif feat == feat_maximize_spell:
 					minLevel = 3
+				elif feat == feat_widen_spell:
+					minLevel = 3
 				elif feat == feat_empower_spell:
 					minLevel = 2
 				


### PR DESCRIPTION
Fixed ultimate magus treating widen spell as if it only required one spell slot higher instead of three.