### PR TITLE
Add a scale factor for the console/dm text

### DIFF
--- a/TemplePlus/config/config.cpp
+++ b/TemplePlus/config/config.cpp
@@ -140,6 +140,7 @@ static ConfigSetting configSettings[] = {
 	CONF_STRING(defaultModule),
 	CONF_INT(windowWidth),
 	CONF_INT(windowHeight),
+	CONF_DOUBLE(dmGuiScale),
 	CONF_BOOL(enlargeDialogFonts),
 	CONF_BOOL(windowedLockCursor),
 	CONF_BOOL(dungeonMaster),

--- a/TemplePlus/config/config.h
+++ b/TemplePlus/config/config.h
@@ -54,7 +54,7 @@ struct TemplePlusConfig
 	bool debugClipping = false;
 	bool drawObjCylinders = false;
 	bool newAnimSystem = false;
-	float dmGuiScale = 3.0f;
+	float dmGuiScale = 1.0f;
 
 	bool autoUpdate = true;
 	std::string autoUpdateFeed = "https://templeplus.org/update-feeds/stable/";

--- a/TemplePlus/config/config.h
+++ b/TemplePlus/config/config.h
@@ -54,6 +54,7 @@ struct TemplePlusConfig
 	bool debugClipping = false;
 	bool drawObjCylinders = false;
 	bool newAnimSystem = false;
+	float dmGuiScale = 3.0f;
 
 	bool autoUpdate = true;
 	std::string autoUpdateFeed = "https://templeplus.org/update-feeds/stable/";

--- a/TemplePlus/dungeon_master.cpp
+++ b/TemplePlus/dungeon_master.cpp
@@ -120,6 +120,7 @@ void DungeonMaster::Render() {
 	}
 	auto wndPos = ImGui::GetWindowPos();
 	auto wndWidth = ImGui::GetWindowWidth();
+	auto ImGui::SetWindowFontScale(2.0f);
 	dmPortraitRect.x = (int)(wndPos.x + wndWidth / 2 - dmPortraitRect.width / 2); dmPortraitRect.y = (int)(wndPos.y - dmPortraitRect.height);
 
 	auto blyat = gameView->MapToScene(dmPortraitRect.x, dmPortraitRect.y);//gameView->MapFromScene(config.renderWidth - dmPortraitRect.x     , config.renderHeight - -dmPortraitRect.y);

--- a/TemplePlus/dungeon_master.cpp
+++ b/TemplePlus/dungeon_master.cpp
@@ -120,6 +120,7 @@ void DungeonMaster::Render() {
 	}
 	auto wndPos = ImGui::GetWindowPos();
 	auto wndWidth = ImGui::GetWindowWidth();
+	ImGui::SetWindowFontScale(3.0f);
 	dmPortraitRect.x = (int)(wndPos.x + wndWidth / 2 - dmPortraitRect.width / 2); dmPortraitRect.y = (int)(wndPos.y - dmPortraitRect.height);
 
 	auto blyat = gameView->MapToScene(dmPortraitRect.x, dmPortraitRect.y);//gameView->MapFromScene(config.renderWidth - dmPortraitRect.x     , config.renderHeight - -dmPortraitRect.y);

--- a/TemplePlus/dungeon_master.cpp
+++ b/TemplePlus/dungeon_master.cpp
@@ -120,7 +120,7 @@ void DungeonMaster::Render() {
 	}
 	auto wndPos = ImGui::GetWindowPos();
 	auto wndWidth = ImGui::GetWindowWidth();
-	ImGui::SetWindowFontScale(3.0f);
+	ImGui::SetWindowFontScale(config.dmGuiScale);
 	dmPortraitRect.x = (int)(wndPos.x + wndWidth / 2 - dmPortraitRect.width / 2); dmPortraitRect.y = (int)(wndPos.y - dmPortraitRect.height);
 
 	auto blyat = gameView->MapToScene(dmPortraitRect.x, dmPortraitRect.y);//gameView->MapFromScene(config.renderWidth - dmPortraitRect.x     , config.renderHeight - -dmPortraitRect.y);

--- a/TemplePlus/dungeon_master.cpp
+++ b/TemplePlus/dungeon_master.cpp
@@ -120,7 +120,7 @@ void DungeonMaster::Render() {
 	}
 	auto wndPos = ImGui::GetWindowPos();
 	auto wndWidth = ImGui::GetWindowWidth();
-	auto ImGui::SetWindowFontScale(2.0f);
+	ImGui::SetWindowFontScale(3.0f);
 	dmPortraitRect.x = (int)(wndPos.x + wndWidth / 2 - dmPortraitRect.width / 2); dmPortraitRect.y = (int)(wndPos.y - dmPortraitRect.height);
 
 	auto blyat = gameView->MapToScene(dmPortraitRect.x, dmPortraitRect.y);//gameView->MapFromScene(config.renderWidth - dmPortraitRect.x     , config.renderHeight - -dmPortraitRect.y);

--- a/TemplePlus/dungeon_master.cpp
+++ b/TemplePlus/dungeon_master.cpp
@@ -120,7 +120,6 @@ void DungeonMaster::Render() {
 	}
 	auto wndPos = ImGui::GetWindowPos();
 	auto wndWidth = ImGui::GetWindowWidth();
-	ImGui::SetWindowFontScale(3.0f);
 	dmPortraitRect.x = (int)(wndPos.x + wndWidth / 2 - dmPortraitRect.width / 2); dmPortraitRect.y = (int)(wndPos.y - dmPortraitRect.height);
 
 	auto blyat = gameView->MapToScene(dmPortraitRect.x, dmPortraitRect.y);//gameView->MapFromScene(config.renderWidth - dmPortraitRect.x     , config.renderHeight - -dmPortraitRect.y);

--- a/TemplePlus/mainloop.cpp
+++ b/TemplePlus/mainloop.cpp
@@ -504,6 +504,7 @@ public:
 			// We have to manually trigger a new frame for the debug UI here since 
 			// this can be called from virtually anywhere
 			ImGui::NewFrame();
+			ImGui::GetIO().FontGlobalScale = 3.0f;
 
 			return 0;
 		});

--- a/TemplePlus/mainloop.cpp
+++ b/TemplePlus/mainloop.cpp
@@ -504,7 +504,6 @@ public:
 			// We have to manually trigger a new frame for the debug UI here since 
 			// this can be called from virtually anywhere
 			ImGui::NewFrame();
-			ImGui::GetIO().FontGlobalScale = 3.0f;
 
 			return 0;
 		});

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -394,6 +394,7 @@ void Console::RenderCheatsMenu()
 			}
 
 			if (ImGui::BeginMenu("Speedup")){
+				ImGui::SetWindowFontScale(config.dmGuiScale);
 				auto speedupCb = [](int speedupVal) {
 					auto N_party = party.GroupListGetLen();
 					auto speedRun = 1.0f;

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -47,6 +47,7 @@ void Console::Render()
 	size.y = max(300.0f, size.y*0.4f);
 	ImGui::SetNextWindowSize(size);
 	ImGui::SetNextWindowPos(consPos);
+	ImGui::SetWindowFontScale(3.0f);
 	if (!ImGui::Begin("Console", &mOpen, consoleWidgeFlags)){
 		ImGui::End();
 		return;

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -52,6 +52,7 @@ void Console::Render()
 		return;
 	}
 
+	ImGui::SetWindowFontScale(3.0f);
 	RenderCheatsMenu();
 	
 	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false, ImGuiWindowFlags_HorizontalScrollbar);

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -253,6 +253,7 @@ void Console::RenderCheatsMenu()
 	{
 		if (ImGui::BeginMenu("Cheats"))
 		{
+			ImGui::SetWindowFontScale(config.dmGuiScale);
 			if (ImGui::MenuItem("Level Up")) {
 				for (auto i = 0u; i < party.GroupListGetLen(); i++) {
 					auto handle = party.GroupListGetMemberN(i);
@@ -435,6 +436,7 @@ void Console::RenderCheatsMenu()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Debug")) {
+			ImGui::SetWindowFontScale(config.dmGuiScale);
 			if (ImGui::MenuItem("Debug Console")) {
 				UIShowDebug();
 			}
@@ -460,6 +462,7 @@ void Console::RenderCheatsMenu()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Edit")){
+			ImGui::SetWindowFontScale(config.dmGuiScale);
 
 			static char dialogHandleInput[256] = { 0, };
 			static std::string dialogFilename;

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -51,11 +51,12 @@ void Console::Render()
 		ImGui::End();
 		return;
 	}
+	ImGui::SetWindowFontScale(config.dmGuiScale);
 
-	ImGui::SetWindowFontScale(3.0f);
 	RenderCheatsMenu();
 	
 	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false, ImGuiWindowFlags_HorizontalScrollbar);
+	ImGui::SetWindowFontScale(config.dmGuiScale);
 	if (ImGui::BeginPopupContextWindow())
 	{
 		if (ImGui::Selectable("Clear")) Clear();

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -52,7 +52,6 @@ void Console::Render()
 		return;
 	}
 
-	ImGui::SetWindowFontScale(3.0f);
 	RenderCheatsMenu();
 	
 	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false, ImGuiWindowFlags_HorizontalScrollbar);

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -47,12 +47,12 @@ void Console::Render()
 	size.y = max(300.0f, size.y*0.4f);
 	ImGui::SetNextWindowSize(size);
 	ImGui::SetNextWindowPos(consPos);
-	ImGui::SetWindowFontScale(3.0f);
 	if (!ImGui::Begin("Console", &mOpen, consoleWidgeFlags)){
 		ImGui::End();
 		return;
 	}
 
+	ImGui::SetWindowFontScale(3.0f);
 	RenderCheatsMenu();
 	
 	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false, ImGuiWindowFlags_HorizontalScrollbar);


### PR DESCRIPTION
This adds a (currently file-only) configuration value that controls the font scaling factor in the imgui stuff implementing the top console and dungeon master UI.

Most stuff in the game is (I think) drawn at the resolution set in the Temple+ config and then scaled to your screen's actual resolution, so it gets scaled. However, the imgui stuff gets drawn at the actual screen resolution. So, if you have something like a 4K monitor, it ends up pretty small. This lets you put e.g. `dmGuiScale = 2.0` in the .ini file to get a more legible result. Or you could scale it even bigger if you want.

I could add it to the configuration app, but I'm not sure where to put it in the UI. Right now you just have to edit the ini file by hand. After you run Temple+ once the default value (1.0) will be in the file, so you don't have to guess the name, but it might not be obvious that it's there. Let me know if you have ideas of where would be good to put the configuration.

Also, if anyone knows a better way to use the scaling in the imgui, let me know. Right now it's just calling the per-window scale factor function on every window. I tried setting the global font scale factor at the start, but it didn't seem to work. Maybe I didn't do it quite right, though. Not sure.