### PR TITLE
Clairify one handed wield with a comment.

### DIFF
--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -1663,10 +1663,11 @@ int GenericCallbacks::FastHealingOnBeginRound(DispatcherCallbackArgs args)
 int GenericCallbacks::PreferOneHandedWieldRadialMenu(DispatcherCallbackArgs args)
 {
 	auto shield = inventory.ItemWornAt(args.objHndCaller, EquipSlot::Shield);
-	if (shield) {
-		if (!inventory.IsBuckler(shield))
-			return 0;
-	}
+
+	//There is no reason to perfer attacking one handed unless the character is using a buckler.
+	//If they don't have a buckler, don't display the menu.
+	if (!inventory.IsBuckler(shield))
+		return 0;
 
 	RadialMenuEntryToggle radEntry(5124, args.GetCondArgPtr(0), "TAG_RADIAL_MENU_PREFER_ONE_HANDED_WIELD");
 	radEntry.AddChildToStandard(args.objHndCaller, RadialMenuStandardNode::Options);

--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -1663,8 +1663,10 @@ int GenericCallbacks::FastHealingOnBeginRound(DispatcherCallbackArgs args)
 int GenericCallbacks::PreferOneHandedWieldRadialMenu(DispatcherCallbackArgs args)
 {
 	auto shield = inventory.ItemWornAt(args.objHndCaller, EquipSlot::Shield);
-	if (!inventory.IsBuckler(shield))
-		return 0;
+	if (shield) {
+		if (!inventory.IsBuckler(shield))
+			return 0;
+	}
 
 	RadialMenuEntryToggle radEntry(5124, args.GetCondArgPtr(0), "TAG_RADIAL_MENU_PREFER_ONE_HANDED_WIELD");
 	radEntry.AddChildToStandard(args.objHndCaller, RadialMenuStandardNode::Options);


### PR DESCRIPTION
Currently the option only displays when the character has a buckler which seems like a bug.  This is due to is buckler returning false when the input is null.  Now it should display whenever a character has no shield.  Should it only display for medium sized or larger weapons?