### PR TITLE
Eliminate size check from weapon feat check

### DIFF
--- a/TemplePlus/feat.cpp
+++ b/TemplePlus/feat.cpp
@@ -1575,8 +1575,6 @@ int _IsWeaponSpecializationFeat(feat_enums feat)
 
 uint32_t _WeaponFeatCheck(objHndl objHnd, feat_enums * featArray, uint32_t featArrayLen, Stat classBeingLeveled, WeaponTypes wpnType)
 {
-	if (templeFuncs.sub_100664B0(objHnd, wpnType) == 3){ return 0; } // 3 means weapon size is more than wielder size+1
-
 	if (weapons.IsSimple(wpnType))
 	{
 		if (feats.HasFeatCountByClass(objHnd, FEAT_SIMPLE_WEAPON_PROFICIENCY, classBeingLeveled, 0))


### PR DESCRIPTION
This is a simple change. It just eliminates the weapon size test from `_WeaponFeatCheck`.

This test was bad for multiple reasons.

1. Weapon sizing isn't supposed to affect proficiency. There's a separate system of penalties if you're using inappropriately sized weapons. And you don't need to mark too-large weapons as non-proficient to prevent people from equipping them or something (because it doesn't do that), and that was the test it was doing.
2. The test was using a hard-coded list of weapon sizes that only accounted for the medium versions. It was saying that e.g. small characters are never proficient in quarterstaves, because they are too small to wield a medium quarterstaff. So, even though the game contains a small quarterstaff, which is marked as the appropriate size in the proto, this check would say they are non-proficient.

So, just deleting the test seems the right thing to do. I checked, and small characters are still not allowed to equip medium quarterstaves (that is handled by a separate function that _does_ look at the proto value).

Fixes #806 and Atari bugs 406 and 582.