### PR TITLE
Use global font scaling for all imgui

### DIFF
--- a/TemplePlus/dungeon_master.cpp
+++ b/TemplePlus/dungeon_master.cpp
@@ -113,14 +113,14 @@ void DungeonMaster::Render() {
 		//ImGui::SetWindowCollapsed(true);
 		mFlist.clear();
 	}
-		
+
 	isMinimized = ImGui::GetWindowCollapsed();
 	if (isMinimized && IsActionActive()) {
 		DeactivateAction();
 	}
 	auto wndPos = ImGui::GetWindowPos();
 	auto wndWidth = ImGui::GetWindowWidth();
-	ImGui::SetWindowFontScale(config.dmGuiScale);
+	ImGui::GetIO().FontGlobalScale = config.dmGuiScale;
 	dmPortraitRect.x = (int)(wndPos.x + wndWidth / 2 - dmPortraitRect.width / 2); dmPortraitRect.y = (int)(wndPos.y - dmPortraitRect.height);
 
 	auto blyat = gameView->MapToScene(dmPortraitRect.x, dmPortraitRect.y);//gameView->MapFromScene(config.renderWidth - dmPortraitRect.x     , config.renderHeight - -dmPortraitRect.y);

--- a/TemplePlus/dungeon_master_obj_editor.cpp
+++ b/TemplePlus/dungeon_master_obj_editor.cpp
@@ -9,6 +9,7 @@
 #include "python/python_integration_obj.h"
 #include "python/python_header.h"
 
+#include "config/config.h"
 #include "dungeon_master.h"
 
 
@@ -119,6 +120,8 @@ void DungeonMaster::RenderEditedObj() {
 	auto obj = objSystem->GetObject(mEditedObj);
 	if (!obj)
 		return;
+
+	ImGui::GetIO().FontGlobalScale = config.dmGuiScale;
 
 	ImGui::Text(fmt::format("Name: {} , Proto: {}", critEditor.name, objSystem->GetProtoId(mEditedObj)).c_str());
 

--- a/TemplePlus/tig/tig_console.cpp
+++ b/TemplePlus/tig/tig_console.cpp
@@ -35,6 +35,8 @@ void Console::Render()
 
 	constexpr auto consoleWidgeFlags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_MenuBar;
 
+	ImGui::GetIO().FontGlobalScale = config.dmGuiScale;
+
 	auto size = ImGui::GetIO().DisplaySize;
 	ImVec2 consPos(0, 0);
 	if (gameView) {
@@ -51,12 +53,10 @@ void Console::Render()
 		ImGui::End();
 		return;
 	}
-	ImGui::SetWindowFontScale(config.dmGuiScale);
 
 	RenderCheatsMenu();
 	
 	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false, ImGuiWindowFlags_HorizontalScrollbar);
-	ImGui::SetWindowFontScale(config.dmGuiScale);
 	if (ImGui::BeginPopupContextWindow())
 	{
 		if (ImGui::Selectable("Clear")) Clear();
@@ -253,7 +253,6 @@ void Console::RenderCheatsMenu()
 	{
 		if (ImGui::BeginMenu("Cheats"))
 		{
-			ImGui::SetWindowFontScale(config.dmGuiScale);
 			if (ImGui::MenuItem("Level Up")) {
 				for (auto i = 0u; i < party.GroupListGetLen(); i++) {
 					auto handle = party.GroupListGetMemberN(i);
@@ -394,7 +393,6 @@ void Console::RenderCheatsMenu()
 			}
 
 			if (ImGui::BeginMenu("Speedup")){
-				ImGui::SetWindowFontScale(config.dmGuiScale);
 				auto speedupCb = [](int speedupVal) {
 					auto N_party = party.GroupListGetLen();
 					auto speedRun = 1.0f;
@@ -437,7 +435,6 @@ void Console::RenderCheatsMenu()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Debug")) {
-			ImGui::SetWindowFontScale(config.dmGuiScale);
 			if (ImGui::MenuItem("Debug Console")) {
 				UIShowDebug();
 			}
@@ -463,7 +460,6 @@ void Console::RenderCheatsMenu()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Edit")){
-			ImGui::SetWindowFontScale(config.dmGuiScale);
 
 			static char dialogHandleInput[256] = { 0, };
 			static std::string dialogFilename;


### PR DESCRIPTION
This is an improvement on the previous imgui scaling patch. I figured out how to use the global scale setting. This means that

- Now the object editor (when you right click on a critter with the DM open) is properly scaled. I'd completely missed that last time.
- Various drop downs are now scaled properly. I'm not sure how to even get them to scale using the per-window scaling, because they just use a call to one of the imgui functions with a list of strings.

