### PR TITLE
Fix scribed scrolls not working for destroying the golden orb of death.

### DIFF
--- a/TemplePlus/ui/ui_item_creation.cpp
+++ b/TemplePlus/ui/ui_item_creation.cpp
@@ -989,6 +989,8 @@ void UiItemCreation::CraftScrollWandPotionSetItemSpellData(objHndl objHndItem, o
 		}
 		auto newNameId = description.CustomNameNew(newName);
 		obj->SetInt32(obj_f_description, newNameId);
+
+		//Fix name id for fireball and gust of wind otherwise Pishella won't accept them for the golden orb of death
 		if (mScribedScrollSpell == 171) {
 			obj->SetInt32(obj_f_name, 4003);
 		}

--- a/TemplePlus/ui/ui_item_creation.cpp
+++ b/TemplePlus/ui/ui_item_creation.cpp
@@ -989,6 +989,12 @@ void UiItemCreation::CraftScrollWandPotionSetItemSpellData(objHndl objHndItem, o
 		}
 		auto newNameId = description.CustomNameNew(newName);
 		obj->SetInt32(obj_f_description, newNameId);
+		if (mScribedScrollSpell == 171) {
+			obj->SetInt32(obj_f_name, 4003);
+		}
+		else if (mScribedScrollSpell == 214) {
+			obj->SetInt32(obj_f_name, 4004);
+		}
 		return;
 	};
 
@@ -1157,7 +1163,7 @@ void UiItemCreation::ItemCreationCraftingCostTexts(int widgetId, objHndl objHndI
 	uint32_t craftingCostCP;
 	uint32_t craftingCostXP;
 	TigRect rect(212 + 108 * mUseCo8Ui, 157, 159, 10);
-	char * prereqString;
+	char * prereqString = nullptr;
 
 	int casterLevelNew = -1;
 	auto itemWorth = 0;


### PR DESCRIPTION
Fixed name id for fireball and gust of wind scrolls that are scribed. Fixes issue #825 where the golden orb cannot be destroyed.

Closes #825