### PR TITLE
Use ag_animate for dismiss animation

### DIFF
--- a/TemplePlus/animgoals/anim.cpp
+++ b/TemplePlus/animgoals/anim.cpp
@@ -506,10 +506,13 @@ BOOL AnimSystem::PushSpellCast(SpellPacketBody & spellPkt, objHndl item)
 BOOL AnimSystem::PushSpellDismiss(SpellPacketBody & pkt)
 {
     AnimSlotGoalStackEntry goalData;
-    if (!goalData.InitWithInterrupt(pkt.caster, ag_throw_spell_w_cast_anim))
+    if (!goalData.InitWithInterrupt(pkt.caster, ag_animate))
         return FALSE;
 
     SetGoalDataForSpellPacket(pkt, goalData, true, true);
+
+		// adjust combined numbering to normal anim type numbering
+		goalData.animIdPrevious.number -= 64;
 
     return goalData.Push(nullptr);
 }


### PR DESCRIPTION
This is a quick fix for some issues I noticed with dismissing certain spells. For instance, I noticed that when you dismiss Silence, it actually restarts the spell.

The issue goes back to when I added spell dismissal animations. I mistakenly thought it was safe to use one of the spell casting animation goals for that. But, the problem is that the animation sequences actually contain callbacks the execute game logic in response to certain portions of the animation completing. So, using the `ag_throw_spell_w_cast_anim` sequence will actually trigger some of the python calls.

In most cases this actually turns out not to be a problem, which I guess is why I didn't notice. For most spells, the dismiss event ends the spell, and the script triggers don't resume it. _However_, there are some spells that lack the right dismiss handling. In vanilla ToEE, that means that when you click `Dismiss Spell`, nothing happens. Grease and Silence are examples. Temple+ fixed this by making the `Dismiss` handler also call some of the spell ending functions. But apparently that isn't good enough because the wrong animation sequence can result in the spell being refreshed.

So, this switches to making dismiss use the `ag_animate` goal, which is used in e.g. `anim_goal_push` in python. I think it just plays the animation without any of the game logic.

Sorry I didn't catch this earlier. I guess you could consider it something caught in 'beta testing' the next release. :)