### PR TITLE
Use base radius for clearance in pathfinding

### DIFF
--- a/TemplePlus/obj.cpp
+++ b/TemplePlus/obj.cpp
@@ -440,7 +440,7 @@ float AdjustRadiusSize(float baseRadius, int baseSize, int curSize)
 	return radius;
 }
 
-float Objects::GetRadius(objHndl handle)
+float Objects::GetRadius(objHndl handle, bool base)
 {
 	auto obj = gameSystems->GetObj().GetObject(handle);
 	auto radiusSet = obj->GetFlags() & OF_RADIUS_SET;
@@ -465,7 +465,9 @@ float Objects::GetRadius(objHndl handle)
 				}
 			}
 
-			radius = AdjustRadiusSize(radius, baseSize, curSize);
+			if (!base) {
+				radius = AdjustRadiusSize(radius, baseSize, curSize);
+			}
 		}
 		if (radius < 2000.0 && radius > 0)
 		{

--- a/TemplePlus/obj.h
+++ b/TemplePlus/obj.h
@@ -87,7 +87,7 @@ struct Objects : temple::AddressTable {
 	int GetNameId(objHndl handle) {
 		return _GetInternalFieldInt32(handle, obj_f_name);
 	}
-	float GetRadius(objHndl handle);
+	float GetRadius(objHndl handle, bool base = false);
 	void SetRadius(objHndl handle, float radius) {
 		_SetInternalFieldFloat(handle, obj_f_radius, radius);
 	}

--- a/TemplePlus/pathfinding.cpp
+++ b/TemplePlus/pathfinding.cpp
@@ -1200,7 +1200,7 @@ int Pathfinding::FindPathShortDistanceAdjRadius(PathQuery* pq, Path* pqr)
 	int newIdx, shiftedXidx, shiftedYidx, deltaIdxX, distanceMetric, refererIdx, heuristic, idxPrevChain, idxNextChain;
 	int minHeuristic = 0x7FFFffff;
 
-	float requisiteClearance = objects.GetRadius(pq->critter);
+	float requisiteClearance = objects.GetRadius(pq->critter, true);
 	float diagonalClearance = requisiteClearance * 0.7f; // diagonals need to be more restrictive to avoid jaggy paths
 	float requisiteClearanceCritters = requisiteClearance * 0.7f;
 	if (requisiteClearance > 12)
@@ -2191,7 +2191,7 @@ int Pathfinding::FindPathShortDistanceSansTarget(PathQuery* pq, Path* pqr)
 
 	float requisiteClearance = 1.0f;
 	if (pq->critter)
-		requisiteClearance = objects.GetRadius(pq->critter);
+		requisiteClearance = objects.GetRadius(pq->critter, true);
 	float diagonalClearance = requisiteClearance * 0.7f;
 	float requisiteClearanceCritters = requisiteClearance * 0.7f;
 	if (requisiteClearance > 12)


### PR DESCRIPTION
Allows PCs through doors they'd normally be able to get through as in the base game.