### PR TITLE
Add debugging/default to physical stat functions

### DIFF
--- a/TemplePlus/gamesystems/d20/d20stats.cpp
+++ b/TemplePlus/gamesystems/d20/d20stats.cpp
@@ -308,6 +308,11 @@ int D20StatsSystem::GetPsiStatBase(const objHndl & handle, Stat stat, int statAr
 
 int D20StatsSystem::GetPhysicalStatBase(const objHndl & handle, Stat stat) const
 {
+	if (!handle) {
+		logger->debug("GetPhysicalStatBase called with null handle for stat {}", stat);
+		return 0;
+	}
+
 	switch(stat){
 	case stat_ac:
 		return critterSys.GetArmorClass(handle);
@@ -356,6 +361,11 @@ int D20StatsSystem::GetPhysicalStatLevel(const objHndl & handle, Stat stat) cons
 	auto sizeDiff = curSize - baseSize;
 
 	int base = 0;
+
+	if (!handle) {
+		logger->debug("GetPhysicalStatLevel called with null handle for stat {}", stat);
+		return 0;
+	}
 
 	// TODO: polymorph
 	switch(stat) {

--- a/TemplePlus/gamesystems/d20/d20stats.cpp
+++ b/TemplePlus/gamesystems/d20/d20stats.cpp
@@ -309,7 +309,6 @@ int D20StatsSystem::GetPsiStatBase(const objHndl & handle, Stat stat, int statAr
 int D20StatsSystem::GetPhysicalStatBase(const objHndl & handle, Stat stat) const
 {
 	if (!handle) {
-		logger->debug("GetPhysicalStatBase called with null handle for stat {}", stat);
 		return 0;
 	}
 
@@ -356,16 +355,15 @@ int D20StatsSystem::GetPhysicalStatBase(const objHndl & handle, Stat stat) const
 
 int D20StatsSystem::GetPhysicalStatLevel(const objHndl & handle, Stat stat) const
 {
+	if (!handle) {
+		return 0;
+	}
+
 	auto curSize = objects.GetSize(handle, false);
 	auto baseSize = objects.GetSize(handle, true);
 	auto sizeDiff = curSize - baseSize;
 
 	int base = 0;
-
-	if (!handle) {
-		logger->debug("GetPhysicalStatLevel called with null handle for stat {}", stat);
-		return 0;
-	}
 
 	// TODO: polymorph
 	switch(stat) {


### PR DESCRIPTION
When going to debug the physical stat functions, I also had it just return 0 when the handle is null, and that seems to fix the crash when (some) NPCs are killed.

What seems to happen is that the game prints some NPCs' dying words by calling the function for speaking to someone with a null `speakingTo`. This eventually tries to look up the gender of `speakingTo` to get the right dialogue/sound, which would bomb with a null handle (direct getInt32 on a null object). There seem to be other scenarios where `speakingTo` is null, too, so it isn't just for dying creatures.

There was already a replacement adding a null check to the DLL physical stat function, but I didn't notice it when rewriting the functions directly, so I didn't add null checks, and bypassed the existing null check when calling from `StatLevelGet(Base)`.

I can remove the debug logging if we think that it's not really an erroneous case.