### PR TITLE
Fix new base classes not getting starting equipment

### DIFF
--- a/TemplePlus/python/python_integration_obj.cpp
+++ b/TemplePlus/python/python_integration_obj.cpp
@@ -74,15 +74,17 @@ static void PcStart(objHndl pc) {
 	inventory.Clear(pc, FALSE);
 	
 	// This checks that the PC has at least one level in any of the classes
-	auto stat = d20ClassSys.vanillaClassEnums[0];
-	auto classIndex = 0;
-	while (classIndex <= VANILLA_NUM_CLASSES) {
-		stat = d20ClassSys.vanillaClassEnums[classIndex];
+	int classIndex = 0;
+	for (auto classEnum : d20ClassSys.baseClassEnums) {
+		auto stat = static_cast<Stat>(classEnum);
+
 		if (objects.StatLevelGet(pc, stat) > 0) break;
+
 		classIndex++;
-		if (classIndex >= VANILLA_NUM_CLASSES)
-			return;
 	}
+
+	// couldn't find class
+	if (classIndex > d20ClassSys.baseClassEnums.size()) return;
 
 	try {
 		auto content(MesFile::ParseFile("rules\\start_equipment.mes"));

--- a/TemplePlus/python/python_integration_obj.cpp
+++ b/TemplePlus/python/python_integration_obj.cpp
@@ -86,6 +86,9 @@ static void PcStart(objHndl pc) {
 	// couldn't find class
 	if (classIndex > d20ClassSys.baseClassEnums.size()) return;
 
+	// offset by 1 for tutorial inventory
+	if (classIndex >= VANILLA_NUM_CLASSES) classIndex++;
+
 	try {
 		auto content(MesFile::ParseFile("rules\\start_equipment.mes"));
 		

--- a/tpdatasrc/co8infra/rules/start_equipment.mes
+++ b/tpdatasrc/co8infra/rules/start_equipment.mes
@@ -42,20 +42,23 @@
 // wizard 
 {10}{6142} 
 
-// favored soul
-{11}{6142}
+// tutorial
+{11}{6047 6032 6011 6012}
 
-// scout
+// favored soul
 {12}{6142}
 
-// warmage
+// scout
 {13}{6142}
 
-// beguiler
+// warmage
 {14}{6142}
 
-// swashbuckler
+// beguiler
 {15}{6142}
+
+// swashbuckler
+{16}{6142}
 
 // Small size races (halflings and gnomes) 
 
@@ -93,16 +96,16 @@
 {110}{6142} 
 
 // favored soul
-{111}{6142}
-
-// scout
 {112}{6142}
 
-// warmage
+// scout
 {113}{6142}
 
-// beguiler
+// warmage
 {114}{6142}
 
-// swashbuckler
+// beguiler
 {115}{6142}
+
+// swashbuckler
+{116}{6142}

--- a/tpdatasrc/co8infra/rules/start_equipment.mes
+++ b/tpdatasrc/co8infra/rules/start_equipment.mes
@@ -1,6 +1,12 @@
 // This file defines starting equipment for each class. Each line is a list 
 // of items specified by their prototype number 
 
+// Note: Not all base classes are enabled currently. These indices (first
+// number) are position in the list of all base classes sorted by class enum.
+// When more base classes are enabled it might shift some positions.
+
+// Doesn't matter currently since everyone gets the same farmer garb
+
 // Medium size races 
 
 // barbarian 
@@ -36,8 +42,20 @@
 // wizard 
 {10}{6142} 
 
-// tutorial 
-{11}{6047 6032 6011 6012}
+// favored soul
+{11}{6142}
+
+// scout
+{12}{6142}
+
+// warmage
+{13}{6142}
+
+// beguiler
+{14}{6142}
+
+// swashbuckler
+{15}{6142}
 
 // Small size races (halflings and gnomes) 
 
@@ -73,3 +91,18 @@
 
 // wizard 
 {110}{6142} 
+
+// favored soul
+{111}{6142}
+
+// scout
+{112}{6142}
+
+// warmage
+{113}{6142}
+
+// beguiler
+{114}{6142}
+
+// swashbuckler
+{115}{6142}

--- a/tpdatasrc/co8infra/rules/start_equipment.mes
+++ b/tpdatasrc/co8infra/rules/start_equipment.mes
@@ -7,6 +7,9 @@
 
 // Doesn't matter currently since everyone gets the same farmer garb
 
+// Note 2: offsets for new base classes are shifted by 1 because the tutorial
+// is hard coded to #11.
+
 // Medium size races 
 
 // barbarian 


### PR DESCRIPTION
The function that loops over classes and calls the python `pc_start` function was only checking for vanilla classes. I changed it to loop over all the base classes instead, because `pc_start` is how you get bonus items for exotic weapon proficiencies and focus.

I also augmented the Co8 `start_equipment.mes` to give farmer clothes to the new classes. It probably doesn't matter because I assume everyone throws those away, but it's consistent at least.

In other modules they still won't get a starting loadout, but we don't seem to have files for those right now. KoTB has a shop map if I recall correctly, so it probably doesn't matter. Not sure about other mods. Vanilla gives actual loadouts for each class, but I don't actually know where to put stuff for only the original ToEE module.

Fixes #848