### PR TITLE
Avoid dragging rolls during point buy.

### DIFF
--- a/TemplePlus/ui/ui_pc_creation.h
+++ b/TemplePlus/ui/ui_pc_creation.h
@@ -216,6 +216,7 @@ public:
 
 	// stats
 	int GetRolledStatIdx(int x, int y, int *xyOut = nullptr); // gets the index of the Rolled Stats button according to the mouse position. Returns -1 if none.
+	int GetAssignedStatIdx(int x, int y, int *xyOut = nullptr); // gets the index of the Assigned Stats button according to the mouse position. Returns -1 if none.
 	BOOL StatsWndMsg(int widId, TigMsg *msg);
 
 	// Race
@@ -438,6 +439,7 @@ public:
 	}
 
 private:
+	int GetStatIdx(const int x0, const int xMax, int x, int y, int *xyOut);
 
 	int mPageCount = 0;
 


### PR DESCRIPTION
Intercepts mouse events that allow accessing the rolled stats during point buy. Left clicks on the rolled stat boxes are just dropped, and drag events onto the rolled stats are tweaked to appear outside the rolled stats when delegating to the DLL, so that the drag is just aborted.

Fixes Atari bug 338.

As an additional effect, the bug where you can double click on one of the rolled stats to get your roll count as a stat during point buy is also fixed.