### PR TITLE
Don't apply ammo enhancements to attacks with (possibly) throwable weapons.

### DIFF
--- a/TemplePlus/weapon.cpp
+++ b/TemplePlus/weapon.cpp
@@ -356,6 +356,12 @@ int WeaponSystem::GetBaseHardness(WeaponTypes weapon)
 	}
 }
 
+// Note: this does not completely match the original version.
+// It actually determines whether the weapon uses the ammo. The original
+// reports whether the weapon can be used to make a ranged attack while
+// the ammo is equipped. For the latter, thrown weapons always report
+// success. However, this is the wrong behavior for determining whether
+// the ammo's enhancement bonus should apply to attacks with the weapon.
 bool WeaponSystem::AmmoMatchesWeapon(objHndl weapon, objHndl ammoItem)
 {
 	if (objects.GetType(weapon) != obj_t_weapon)

--- a/TemplePlus/weapon.cpp
+++ b/TemplePlus/weapon.cpp
@@ -361,8 +361,6 @@ bool WeaponSystem::AmmoMatchesWeapon(objHndl weapon, objHndl ammoItem)
 	if (objects.GetType(weapon) != obj_t_weapon)
 		return 0;
 	auto ammoType = objects.getInt32(weapon, obj_f_weapon_ammo_type);
-	if (ammoType >= 4 && ammoType < 18) // no ammo required??
-		return 1;
 	if (!ammoItem)
 		return 0;
 	return ammoType == objects.getInt32(ammoItem, obj_f_ammo_type);


### PR DESCRIPTION
This eliminates the automatic success in `AmmoMatchesWeapon` for weapons with ammo types 4 through 17.

The check here seems due to an oddity with thrown weapons. They have an ammo type named the same thing as their weapon type, and it has its own numbering in ammo types. Since thrown items don't actually need separate ammo, and one of the action check functions actually calls the function to match equipped ammo with the relevant ranged weapon, you don't want to be unable to throw something because you also have arrows equipped.

However, that's not all the check actually does. It also results in the ammo being added to the attack packet whenever you were using a weapon that could be thrown, even for melee attacks. And _that_ meant that having e.g. +2 arrows equipped would make your mundane dagger into a +2 dagger, because it would be treated as if the ammo was being used with the dagger (though not used up).

The enhancement bonus also checked for matching ammo, but since it uses the same logic, it would decide to apply it to things that can be thrown.

I've not replaced the `AmmoMatchesWeapon` from the DLL, because if you do that, it will disallow throwing things, as mentioned. However, all uses of the function in C++/Python work with this version, I think. Also, I replaced the enhancement 'to hit' function so that it uses this `AmmoMatchesWeapon`, because otherwise the character sheet will report the wrong info (the character sheet function just puts the ammo item in the attack packet without checking if it makes sense). The damage function was already replaced for something related to this reason it seems, but thrown weapons were a loophole that is closed by these changes.