### PR TITLE
Fix some errors related to sneak attack and uncanny dodge

### DIFF
--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -1127,6 +1127,20 @@ bool LegacyCritterSystem::CanSense(objHndl critter, objHndl tgt)
 	return critterReplacements.CanSense(critter, tgt);
 }
 
+bool LegacyCritterSystem::CanSenseForSneakAttack(objHndl critter, objHndl tgt)
+{
+	auto uncanny = feats.HasFeatCountByClass(critter, FEAT_UNCANNY_DODGE);
+	auto blindfight = feats.HasFeatCountByClass(critter, FEAT_BLIND_FIGHT);
+
+	// for checking melee range
+	auto reach = critterSys.GetNaturalReach(critter);
+	auto dist = locSys.DistanceToObj(critter,tgt);
+
+	if (uncanny || (blindfight && dist <= reach)) return true;
+
+	return CanSense(critter, tgt);
+}
+
 int LegacyCritterSystem::GetSize(objHndl handle)
 {
 	return dispatch.DispatchGetSizeCategory(handle);

--- a/TemplePlus/critter.h
+++ b/TemplePlus/critter.h
@@ -322,6 +322,10 @@ struct LegacyCritterSystem : temple::AddressTable
 	*/
 	bool CanSense(objHndl critter, objHndl tgt); 
 
+	// Checks if critter can sense target well enough to avoid sneak attacks.
+	// Uncanny dodge and blind-fight allow you to retain your dexterity bonus vs.
+	// opponents you can't see (in melee for the latter).
+	bool CanSenseForSneakAttack(objHndl critter, objHndl tgt);
 
 	int GetSize(objHndl handle);
 


### PR DESCRIPTION
This fixes a few issues:

1. The flat-footed condition was unconditionally allowing sneak attacks. Uncanny dodge allows you to retain your dexterity AC bonus while flat-footed, and losing that is the scenario that allows sneak attacks. This fixes part 3 of #852.
2. Uncanny dodge also lets you keep your dexterity AC against opponents you can't see. So does blind-fight in melee. So, I've added a more specialized `CanSense` that incorporates this.
3. Uncanny dodge had some 3.0 cruft that added bonuses against traps above level 11. I think those turned into Trap Sense in 3.5, which is implemented directly in the class condition. So, I replaced those callbacks with no-ops.

I know of some other oddities related to this, but doing them properly involves other issues with invisibility being broken in various ways. So I'm submitting this standalone.