### PR TITLE
Fixes/tweaks with reloading weapons

### DIFF
--- a/TemplePlus/action_sequence.cpp
+++ b/TemplePlus/action_sequence.cpp
@@ -181,8 +181,6 @@ public:
 		{
 			return actSeqSys.ReadyVsApproachOrWithdrawalCount();
 		});
-
-		replaceFunction(0x100903B0, ActionCostReload);
 	}
 } actSeqReplacements;
 

--- a/TemplePlus/action_sequence.cpp
+++ b/TemplePlus/action_sequence.cpp
@@ -232,8 +232,6 @@ ActionSequenceSystem::ActionSequenceSystem()
 	//rebase(GetRemainingMaxMoveLength, 0x1008B8A0);
 	//rebase(TrimPathToRemainingMoveLength, 0x1008B9A0);
 
-	rebase(_CrossBowSthgReload_1008E8A0, 0x1008E8A0);
-
 	rebase(_TurnBasedStatusUpdate, 0x10093950);
 	rebase(_combatTriggerSthg, 0x10093890);
 	rebase(_ProcessPathForReadiedActions,      0x100939D0); 
@@ -1873,24 +1871,6 @@ ActionErrorCode ActionSequenceSystem::AppendReloadAttack(ActnSeq *actSeq, D20Act
 	AttackAppend(actSeq, d20a, tbStat, tbStat->attackModeCode);
 
 	return AEC_OK;
-}
-
-int ActionSequenceSystem::CrossBowSthgReload_1008E8A0(D20Actn* d20a, ActnSeq* actSeq)
-{
-	int result = 0;
-	{ __asm push ecx __asm push esi __asm push ebx __asm push edi};;
-	__asm{
-		mov ecx, this;
-		mov esi, [ecx]._CrossBowSthgReload_1008E8A0;
-		mov eax, d20a;
-		push eax;
-		mov ebx, actSeq;
-		call esi;
-		add esp, 4;
-		mov result, eax;
-	}
-	{ __asm pop edi __asm pop ebx __asm pop esi __asm pop ecx} 
-	return result;
 }
 
 uint32_t ActionSequenceSystem::TurnBasedStatusUpdate(D20Actn* d20a, TurnBasedStatus* tbStatus)

--- a/TemplePlus/action_sequence.cpp
+++ b/TemplePlus/action_sequence.cpp
@@ -106,7 +106,7 @@ public:
 	static int SeqRenderAooMovement(D20Actn*, UiIntgameTurnbasedFlags);
 	static int SeqRenderFuncMove(D20Actn* d20a, UiIntgameTurnbasedFlags flags);
 	static int SeqRenderAttack(D20Actn* d20a, UiIntgameTurnbasedFlags flags);
-	static int ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp); 
+	static ActionErrorCode ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp); 
 
 	static int ChooseTargetCallback(void* a)
 	{
@@ -1730,7 +1730,7 @@ uint32_t ActionSequenceSystem::ActionCostNull(D20Actn* d20Actn, TurnBasedStatus*
 	return 0;
 }
 
-int ActionSequenceSystem::ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp)
+ActionErrorCode ActionSequenceSystem::ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp)
 {
 	return ActnSeqReplacements::ActionCostReload(d20, tbStat, acp);
 }
@@ -4068,16 +4068,16 @@ int ActnSeqReplacements::SeqRenderAttack(D20Actn* d20a, UiIntgameTurnbasedFlags 
 	return 0;
 }
 
-int ActnSeqReplacements::ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp)
+ActionErrorCode ActnSeqReplacements::ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp)
 {
 	// free action by default
 	acp->hourglassCost = 0;
 
-	if (d20->d20Caf & D20CAF_NEED_ANIM_COMPLETED) return 0;
-	if (!combatSys.isCombatActive()) return 0;
+	if (d20->d20Caf & D20CAF_NEED_ANIM_COMPLETED) return AEC_OK;
+	if (!combatSys.isCombatActive()) return AEC_OK;
 
 	auto weapon = inventory.ItemWornAt(d20->d20APerformer, EquipSlot::WeaponPrimary);
-	if (!weapon) return 0;
+	if (!weapon) return AEC_OK;
 
 	// TODO: rapid reload is actually a per-weapon feat per the SRD
 	bool rapid = feats.HasFeatCountByClass(d20->d20APerformer, FEAT_RAPID_RELOAD);
@@ -4104,7 +4104,7 @@ int ActnSeqReplacements::ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat,
 		// free action
 		break;
 	}
-	return 0;
+	return AEC_OK;
 }
 
 void ActnSeqReplacements::AooShaderPacketAppend(LocAndOffsets* loc, int aooShaderId)

--- a/TemplePlus/action_sequence.h
+++ b/TemplePlus/action_sequence.h
@@ -227,7 +227,7 @@ struct ActionSequenceSystem : temple::AddressTable
 	BOOL SimulsAdvance();
 
 	uint32_t ActionCostNull(D20Actn* d20Actn, TurnBasedStatus* turnBasedStatus, ActionCostPacket* actionCostPacket);
-	int (__cdecl *ActionCostReload)(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp); 
+	int __cdecl ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp); 
 	int ActionCostFullAttack(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp);
 	void FullAttackCostCalculate(D20Actn *d20a, TurnBasedStatus *tbStatus, int *baseAttackNumCode, int *bonusAttacks, int *numAttacks, int *attackModeCode);
 	int ActionCostProcess(TurnBasedStatus* tbStat, D20Actn* d20a);

--- a/TemplePlus/action_sequence.h
+++ b/TemplePlus/action_sequence.h
@@ -227,7 +227,7 @@ struct ActionSequenceSystem : temple::AddressTable
 	BOOL SimulsAdvance();
 
 	uint32_t ActionCostNull(D20Actn* d20Actn, TurnBasedStatus* turnBasedStatus, ActionCostPacket* actionCostPacket);
-	int __cdecl ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp); 
+	ActionErrorCode ActionCostReload(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp); 
 	int ActionCostFullAttack(D20Actn *d20, TurnBasedStatus *tbStat, ActionCostPacket *acp);
 	void FullAttackCostCalculate(D20Actn *d20a, TurnBasedStatus *tbStatus, int *baseAttackNumCode, int *bonusAttacks, int *numAttacks, int *attackModeCode);
 	int ActionCostProcess(TurnBasedStatus* tbStat, D20Actn* d20a);

--- a/TemplePlus/action_sequence.h
+++ b/TemplePlus/action_sequence.h
@@ -174,7 +174,6 @@ struct ActionSequenceSystem : temple::AddressTable
 	*/
 	void ProcessSequenceForAoOs(ActnSeq*actSeq, D20Actn * d20a); // actSeq@<ebx>
 	ActionErrorCode AppendReloadAttack(ActnSeq *, D20Actn *, TurnBasedStatus *);
-	int(CrossBowSthgReload_1008E8A0)(D20Actn *d20a, ActnSeq*actSeq); //, ActnSeq *actSeq@<ebx>
 	uint32_t SequencePathSthgSub_10096450(ActnSeq * actSeq, int idx, TurnBasedStatus* tbStat);
 	//10097C20
 	
@@ -242,7 +241,6 @@ struct ActionSequenceSystem : temple::AddressTable
 private:
 	bool (__cdecl *_actionPerformProjectile)();
 	void (__cdecl *_sub_1008BB40)(D20Actn * d20a); // ActnSeq*actSeq@<ebx>, 
-	int(__cdecl* _CrossBowSthgReload_1008E8A0)(D20Actn *d20a); //, ActnSeq *actSeq@<ebx>
 	uint32_t GetRemainingMaxMoveLength(D20Actn *d20a, TurnBasedStatus *actnSthg, float *floatOut); // doesn't take things like having made 5 foot step into account, just a raw calculation
 	int(__cdecl*_TurnBasedStatusUpdate)(D20Actn* d20Actn, TurnBasedStatus* turnBasedStatus);
 	void (__cdecl *_ProcessPathForReadiedActions)(CmbtIntrpts* d20a); // D20Actn*@<eax>

--- a/TemplePlus/action_sequence.h
+++ b/TemplePlus/action_sequence.h
@@ -173,6 +173,7 @@ struct ActionSequenceSystem : temple::AddressTable
 		splits up the movement to move -> aoo movement -> move as necessary
 	*/
 	void ProcessSequenceForAoOs(ActnSeq*actSeq, D20Actn * d20a); // actSeq@<ebx>
+	ActionErrorCode AppendReloadAttack(ActnSeq *, D20Actn *, TurnBasedStatus *);
 	int(CrossBowSthgReload_1008E8A0)(D20Actn *d20a, ActnSeq*actSeq); //, ActnSeq *actSeq@<ebx>
 	uint32_t SequencePathSthgSub_10096450(ActnSeq * actSeq, int idx, TurnBasedStatus* tbStat);
 	//10097C20

--- a/TemplePlus/combat.cpp
+++ b/TemplePlus/combat.cpp
@@ -521,6 +521,14 @@ bool LegacyCombatSystem::AmmoMatchesItemAtSlot(objHndl obj, EquipSlot equipSlot)
 	return weapons.AmmoMatchesWeapon(weapon, ammoItem);
 }
 
+bool LegacyCombatSystem::NeedsToReload(objHndl critter)
+{
+	if (!critter || d20Sys.d20Query(critter, DK_QUE_Polymorphed)) return false;
+
+	auto weapon = critterSys.GetWornItem(critter, EquipSlot::WeaponPrimary);
+	return weapons.IsUnloaded(weapon);
+}
+
 objHndl * LegacyCombatSystem::GetHostileCombatantList(objHndl obj, int * count)
 {
 	int initListLen = GetInitiativeListLength();

--- a/TemplePlus/combat.cpp
+++ b/TemplePlus/combat.cpp
@@ -1183,7 +1183,7 @@ bool LegacyCombatSystem::CombatEnd(){
 		auto N = party.GroupListGetLen();
 		for (auto i=0u; i < N; i++){
 			auto partyMember = party.GroupListGetMemberN(i);
-			temple::GetRef<void(__cdecl)(objHndl)>(0x100B70A0)(partyMember);
+			critterSys.AutoReload(partyMember);
 		}
 		auto combatGiveXp = temple::GetRef<void(__cdecl)()>(0x100B88C0);
 		combatGiveXp();

--- a/TemplePlus/combat.h
+++ b/TemplePlus/combat.h
@@ -38,6 +38,7 @@ struct LegacyCombatSystem : temple::AddressTable {
 	int GetThreateningCrittersAtLoc(objHndl obj, LocAndOffsets* loc, objHndl threateners[40]);
 	objHndl CheckRangedWeaponAmmo(objHndl obj); // checks if the ammo slot item matches a wielded weapon (primary or secondary), and if so, returns it
 	bool AmmoMatchesItemAtSlot(objHndl obj, EquipSlot equipSlot);
+	bool NeedsToReload(objHndl obj);
 	objHndl * GetHostileCombatantList(objHndl obj, int* count); // gets a list from the combat initiative
 	std::vector<objHndl> GetHostileCombatantList(objHndl handle); // gets a list from the combat initiative
 	void GetEnemyListInRange(objHndl obj, float rangeFeet, std::vector<objHndl> & enemies);

--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -181,6 +181,10 @@ private:
 		replaceFunction<uint32_t(__cdecl)(objHndl,ResurrectType,int)>(0x100809C0, [](objHndl critter, ResurrectType type, int clvl) {
 			return critterSys.Resurrect(critter, type, clvl);
 		});
+
+		replaceFunction<int(__cdecl)(objHndl)>(0x100B70A0, [](objHndl critter) {
+			return critterSys.AutoReload(critter) ? 1 : 0;
+		});
 	}
 
 private:
@@ -325,6 +329,31 @@ void LegacyCritterSystem::Attack(objHndl provoked, objHndl agitator, int rangeTy
 	// 0x2 - 
 	// 0x4
 	aiSys.ProvokeHostility(provoked, agitator, rangeType, flags);
+}
+
+bool LegacyCritterSystem::AutoReload(objHndl critter)
+{
+	if (!critter || IsDeadOrUnconscious(critter)) return false;
+	// TODO: more conditions blocking?
+
+	if (!combatSys.NeedsToReload(critter)) return false;
+
+	if (!combatSys.AmmoMatchesItemAtSlot(critter, WeaponPrimary)) {
+		// out of ammo
+		histSys.CreateRollHistoryLineFromMesfile(0, critter, objHndl::null);
+		objects.floats->FloatCombatLine(critter, 44);
+		return false;
+	}
+
+	if (combatSys.isCombatActive()) return false;
+
+	auto weapon = inventory.ItemWornAt(critter, WeaponPrimary);
+	weapons.SetLoaded(weapon);
+
+	objects.floats->FloatCombatLine(critter, 42);
+	histSys.CreateRollHistoryLineFromMesfile(2, critter, objHndl::null);
+
+	return true;
 }
 
 void LegacyCritterSystem::Pickpocket(objHndl handle, objHndl tgt, int & gotCaught){

--- a/TemplePlus/critter.h
+++ b/TemplePlus/critter.h
@@ -199,6 +199,9 @@ struct LegacyCritterSystem : temple::AddressTable
 
 	void Attack(objHndl provoked, objHndl attacker, int rangeType, int flags);
 
+	// returns true if the weapon was actually reloaded
+	bool AutoReload(objHndl critter);
+
 	/*
 		does the gameplay logic for pickpocketing (this gets called at the end of the pickpocket animation)
 	*/

--- a/TemplePlus/d20.cpp
+++ b/TemplePlus/d20.cpp
@@ -3841,11 +3841,13 @@ ActionErrorCode D20ActionCallbacks::AddToStandardAttack(D20Actn * d20a, ActnSeq 
 	if (inventory.IsRangedWeapon(weapon)){
 		ActionCostPacket acp;
 		d20aCopy.d20Caf |= D20CAF_RANGED;
-		if (inventory.IsNormalCrossbow(weapon))	{
+		if (inventory.IsLoadableWeapon(weapon))	{
 			actSeqSys.ActionCostReload(d20a, &tbStatCopy, &acp);
-			if (acp.hourglassCost){
-				d20a->d20ActType = D20A_STANDARD_RANGED_ATTACK;
-				return (ActionErrorCode)actSeqSys.CrossBowSthgReload_1008E8A0(&d20aCopy, actSeq);
+
+			// if reloading isn't free, we can do at most one attack
+			if (acp.hourglassCost) {
+				d20aCopy.d20ActType = D20A_STANDARD_RANGED_ATTACK;
+				return actSeqSys.AppendReloadAttack(actSeq, &d20aCopy, &tbStatCopy);
 			}
 		}
 

--- a/TemplePlus/d20.cpp
+++ b/TemplePlus/d20.cpp
@@ -154,6 +154,7 @@ public:
 
 
 	// Projectile Hit
+	static BOOL ProjectileHitStandard(D20Actn* d20a, objHndl projectile, objHndl obj2);
 	static BOOL ProjectileHitSpell(D20Actn* d20a, objHndl projectile, objHndl obj2);
 	static BOOL ProjectileHitPython(D20Actn* d20a, objHndl projectile, objHndl obj2);
 
@@ -243,6 +244,7 @@ static struct LegacyD20SystemAddresses : temple::AddressTable {
 	uint32_t(__cdecl*AddToSeqStdAttack)(D20Actn*, ActnSeq*, TurnBasedStatus*);
 	uint32_t(__cdecl*ActionCheckStdAttack)(D20Actn*, TurnBasedStatus*);
 	int(__cdecl*TargetWithinReachOfLoc)(objHndl obj, objHndl target, LocAndOffsets* loc);
+	int(__cdecl*ProjectileFunc_RangedAttack)(D20Actn*, objHndl, objHndl);
 	int * actSeqTargetsIdx;
 	objHndl * actSeqTargets; // size 32
 
@@ -258,6 +260,7 @@ static struct LegacyD20SystemAddresses : temple::AddressTable {
 		rebase(TargetWithinReachOfLoc, 0x100B86C0);
 		rebase(actSeqTargetsIdx, 0x118CD2A0);
 		rebase(actSeqTargets, 0x118CD2A8);
+		rebase(ProjectileFunc_RangedAttack, 0x100982E0);
 	}
 } addresses;
 
@@ -465,6 +468,8 @@ void LegacyD20System::NewD20ActionsInit()
 	d20Defs[d20Type].turnBasedStatusCheck = d20Callbacks.StdAttackTurnBasedStatusCheck;
 	d20Defs[d20Type].actionCost = d20Callbacks.ActionCostStandardAttack;
 	d20Defs[d20Type].actionCheckFunc = d20Callbacks.ActionCheckStdRangedAttack;
+	d20Defs[d20Type].projectileHitFunc = d20Callbacks.ProjectileHitStandard;
+	d20Defs[d20Type].actionFrameFunc = d20Callbacks.ActionFrameRangedAttack;
 	//d20Defs[d20Type].actionCost = d20Callbacks.TargetCheckStandardAttack;
 
 	d20Type = D20A_FULL_ATTACK;
@@ -3236,6 +3241,11 @@ BOOL D20ActionCallbacks::ActionFrameTripAttack(D20Actn* d20a){
 	}
 
 	return FALSE;
+}
+
+BOOL D20ActionCallbacks::ProjectileHitStandard(D20Actn *d20a, objHndl projectile, objHndl thrown)
+{
+	return addresses.ProjectileFunc_RangedAttack(d20a, projectile, thrown);
 }
 
 BOOL D20ActionCallbacks::ProjectileHitSpell(D20Actn * d20a, objHndl projectile, objHndl obj2){

--- a/TemplePlus/inventory.h
+++ b/TemplePlus/inventory.h
@@ -114,7 +114,7 @@ struct InventorySystem : temple::AddressTable
 	objHndl FindItemByProtoId(objHndl container, int protoId, bool skipWorn = false);
 
 	
-	int IsNormalCrossbow(objHndl weapon);
+	bool IsLoadableWeapon(objHndl weapon, bool strict = false);
 	int IsThrowingWeapon(objHndl weapon);
 	bool IsGrenade(objHndl weapon);
 	bool UsesWandAnim(const objHndl item);

--- a/TemplePlus/weapon.cpp
+++ b/TemplePlus/weapon.cpp
@@ -429,6 +429,14 @@ bool WeaponSystem::IsUnloaded(objHndl weapon)
 	}
 }
 
+void WeaponSystem::SetLoaded(objHndl weapon)
+{
+	if (!weapon || objects.GetType(weapon) != obj_t_weapon) return;
+
+	auto flags = objects.getInt32(weapon, obj_f_weapon_flags);
+	objects.setInt32(weapon, obj_f_weapon_flags, flags | OWF_WEAPON_LOADED);
+}
+
 bool WeaponSystem::IsRangedWeapon(WeaponTypes wpnType)
 {
 	switch (wpnType) {

--- a/TemplePlus/weapon.cpp
+++ b/TemplePlus/weapon.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "common.h"
+#include "config/config.h"
 #include "weapon.h"
 #include "obj.h"
 
@@ -403,6 +404,28 @@ bool WeaponSystem::IsMeleeWeapon(WeaponTypes wpnType)
 
 	default:
 		return true;
+	}
+}
+
+// Checks if a weapon requires loading and is not loaded.
+bool WeaponSystem::IsUnloaded(objHndl weapon)
+{
+	if (!weapon) return false;
+
+	if (objects.GetType(weapon) != obj_t_weapon) return false;
+
+	bool unloaded = !(objects.getInt32(weapon, obj_f_weapon_flags) & OWF_WEAPON_LOADED);
+
+	switch (objects.GetWeaponType(weapon))
+	{
+	case wt_light_crossbow:
+	case wt_heavy_crossbow:
+		return unloaded;
+	case wt_sling:
+		return config.stricterRulesEnforcement && unloaded;
+	// TODO: repeating crossbows
+	default:
+		return false;
 	}
 }
 

--- a/TemplePlus/weapon.cpp
+++ b/TemplePlus/weapon.cpp
@@ -3,8 +3,19 @@
 #include "config/config.h"
 #include "weapon.h"
 #include "obj.h"
+#include "util/fixes.h"
 
 WeaponSystem weapons;
+
+static class WeaponReplacements : public TempleFix {
+	void apply() override {
+		// replace unload function to allow for more loadable weapons
+		replaceFunction<int (__cdecl)(objHndl)>(0x100657D0, [](objHndl weapon) {
+			weapons.SetUnloaded(weapon);
+			return 0;
+		});
+	}
+} replacements;
 
 std::string WeaponSystem::GetName(WeaponTypes wpnType)
 {
@@ -429,12 +440,38 @@ bool WeaponSystem::IsUnloaded(objHndl weapon)
 	}
 }
 
+bool WeaponSystem::IsLoadable(objHndl weapon, bool strict)
+{
+	if (!weapon || objects.GetType(weapon) != obj_t_weapon) return false;
+
+	switch (objects.GetWeaponType(weapon))
+	{
+	case wt_light_crossbow:
+	case wt_heavy_crossbow:
+		return true;
+	case wt_sling:
+		return strict || config.stricterRulesEnforcement;
+		// TODO: repeating/hand crossbows
+	default:
+		return false;
+	}
+}
+
 void WeaponSystem::SetLoaded(objHndl weapon)
 {
-	if (!weapon || objects.GetType(weapon) != obj_t_weapon) return;
+	if (!IsLoadable(weapon)) return;
 
 	auto flags = objects.getInt32(weapon, obj_f_weapon_flags);
 	objects.setInt32(weapon, obj_f_weapon_flags, flags | OWF_WEAPON_LOADED);
+}
+
+void WeaponSystem::SetUnloaded(objHndl weapon)
+{
+	// set unloaded as a default state even without strict rules
+	if (!IsLoadable(weapon, true)) return;
+
+	auto flags = objects.getInt32(weapon, obj_f_weapon_flags);
+	objects.setInt32(weapon, obj_f_weapon_flags, flags & ~OWF_WEAPON_LOADED);
 }
 
 bool WeaponSystem::IsRangedWeapon(WeaponTypes wpnType)

--- a/TemplePlus/weapon.h
+++ b/TemplePlus/weapon.h
@@ -40,8 +40,10 @@ struct WeaponSystem : temple::AddressTable
 	bool IsThrownOnlyWeapon(WeaponTypes wpnType);
 	bool IsMeleeWeapon(WeaponTypes wpnType);
 	bool IsUnloaded(objHndl weapon);
+	bool IsLoadable(objHndl weapon, bool strict = false);
 
 	void SetLoaded(objHndl weapon);
+	void SetUnloaded(objHndl weapon);
 
 	std::map<WeaponTypes, WeaponTypeProperties> wpnProps;
 	WeaponSystem();

--- a/TemplePlus/weapon.h
+++ b/TemplePlus/weapon.h
@@ -41,6 +41,8 @@ struct WeaponSystem : temple::AddressTable
 	bool IsMeleeWeapon(WeaponTypes wpnType);
 	bool IsUnloaded(objHndl weapon);
 
+	void SetLoaded(objHndl weapon);
+
 	std::map<WeaponTypes, WeaponTypeProperties> wpnProps;
 	WeaponSystem();
 };

--- a/TemplePlus/weapon.h
+++ b/TemplePlus/weapon.h
@@ -39,6 +39,7 @@ struct WeaponSystem : temple::AddressTable
 	bool IsRangedWeapon(WeaponTypes wpnType);
 	bool IsThrownOnlyWeapon(WeaponTypes wpnType);
 	bool IsMeleeWeapon(WeaponTypes wpnType);
+	bool IsUnloaded(objHndl weapon);
 
 	std::map<WeaponTypes, WeaponTypeProperties> wpnProps;
 	WeaponSystem();


### PR DESCRIPTION
This PR tightens up how reloading works.

1. Fixes a bug that caused the projectile animation to be skipped when making individual attacks as part of a full attack with crossbows. Ammo is only consumed at the end of the projectile animation, so this was allowing you to take all your attacks with a crossbow even without Rapid Reload (probably gave you infinite ammo, too).
2. On strict rules only, fixes some erroneous vanilla behavior
    - Reloading a heavy crossbow is a full round action, or a move action with Rapid Reload. Vanilla was move/free exactly like a light crossbow.
    - Makes slings a weapon that requires loading, costing a move action (with no Rapid Reload according to the SRD). I think all relevant reloading behavior has been implemented when this is turned on.

I didn't do anything with repeating or hand crossbows except leave some 'todo' notes. For the latter, it didn't look like there actually are any. For the former, you're supposed to load 5 bolts at a time, which would require additional machinery to track. Also, it seems like they're almost worthless if properly implemented. They require a feat, and they're still slower than light crossbow+Rapid Reload. I think even a heavy repeater is probably worse.

Crossbows have an item condition for manual reloading actions, but I decided to hook into the global radial builder for slings to avoid having to add proto overrides for every module.