### PR TITLE
Trip check now displays touch misses.

### DIFF
--- a/TemplePlus/combat.cpp
+++ b/TemplePlus/combat.cpp
@@ -1917,7 +1917,9 @@ void LegacyCombatSystem::ToHitProcessingPython(D20Actn& d20a)
 
 bool LegacyCombatSystem::TripCheck(objHndl handle, objHndl target){
 	if (d20Sys.d20Query(target, DK_QUE_Untripable))	{
-		histSys.CreateFromFreeText( combatSys.GetCombatMesLine(171)); 
+		std::string historyLine(combatSys.GetCombatMesLine(171));
+		historyLine.push_back('\n');
+		histSys.CreateFromFreeText(historyLine.c_str());
 		return false;
 	}
 

--- a/TemplePlus/d20.cpp
+++ b/TemplePlus/d20.cpp
@@ -3222,14 +3222,14 @@ BOOL D20ActionCallbacks::ActionFrameTripAttack(D20Actn* d20a){
 	auto tgt = d20a->d20ATarget;
 	auto performer = d20a->d20APerformer;
 
+	histSys.CreateRollHistoryString(d20a->rollHistId1);
+	histSys.CreateRollHistoryString(d20a->rollHistId2);
+	histSys.CreateRollHistoryString(d20a->rollHistId0);
+
 	if (!(d20a->d20Caf & D20CAF_HIT))	{
 		combatSys.FloatCombatLine(d20a->d20APerformer, 29); //miss
 		return FALSE;
 	}
-
-	histSys.CreateRollHistoryString(d20a->rollHistId1);
-	histSys.CreateRollHistoryString(d20a->rollHistId2);
-	histSys.CreateRollHistoryString(d20a->rollHistId0);
 
 	// auto tripCheck = temple::GetRef<BOOL(__cdecl)(objHndl, objHndl)>(0x100B6230);
 	if (combatSys.TripCheck(d20a->d20APerformer, tgt))	{


### PR DESCRIPTION
Also untripable text now correctly has a new line character.

Fixes #860