### PR TITLE
Fix a minor bug with TWF defaults and bucklers

### DIFF
--- a/TemplePlus/condition.cpp
+++ b/TemplePlus/condition.cpp
@@ -1869,7 +1869,7 @@ int DefaultSetTWF(DispatcherCallbackArgs args)
 
 	if (uitem == left) { // off hand equipped, default two TWF on
 		args.SetCondArg(0, 1);
-	} else if (uitem == shield) { // shield equipped, default to TWF off
+	} else if (!left && uitem == shield) { // shield equipped, default to TWF off
 		args.SetCondArg(0, 0);
 		args.SetCondArg(1, 0);
 	} else if (uitem == right) { // right hand equipped


### PR DESCRIPTION
The two weapon fighting toggle button listens for inventory events to set default values. When you equip an off hand weapon, it sets TWF to on, and when you equip a shield, it defaults to off.

However, I hadn't accounted for the fact that you can equip a buckler while wielding two weapons. This was setting the toggle off from the shield logic. I've changed it so that it only does this if your off hand is empty. If you do have an off hand weapon, it just leaves the setting alone.