### PR TITLE
Fix two weapon animation logic

### DIFF
--- a/TemplePlus/inventory.cpp
+++ b/TemplePlus/inventory.cpp
@@ -1645,7 +1645,7 @@ bool InventorySystem::IsWieldedTwoHanded(objHndl weapon, objHndl wielder, bool s
 		hasInterferingOffhand = true;
 	}
 	if (shield != objHndl::null){
-		hasInterferingOffhand = !shieldAllowsTwoHandedWield;
+		hasInterferingOffhand |= !shieldAllowsTwoHandedWield;
 	}
 	auto wieldType = GetWieldType(wielder, weapon, true);
 	// the wield type if the weapon is not enlarged along with the critter


### PR DESCRIPTION
When checking whether a character has something in their off hand, the shield logic was overwriting the weapon logic. This is a problem with a buckler, which can be worn with an off hand weapon.

The result was using the two-handed animation for one-handed weapons when wielding an off hand weapon with a buckler. The actual attack/damage logic seems to have been unaffected, because there are additional checks on top. So only animations were affected.