### PR TITLE
Quick fix for Zuggtmoy bargaining dialogue

### DIFF
--- a/tpdatasrc/co8fixes/scr/py00176zuggtmoy.py
+++ b/tpdatasrc/co8fixes/scr/py00176zuggtmoy.py
@@ -53,12 +53,12 @@ def san_start_combat( attachee, triggerer ):
 				if (nearby_pc == OBJ_HANDLE_NULL):
 					nearby_pc = pc
 				if (pc.item_find(2203)):
-					game.new_sid = 0
 					pc.begin_dialog(attachee,330)
+					game.new_sid = 0
 					return RUN_DEFAULT
 		if (nearby_pc != OBJ_HANDLE_NULL):
-			game.new_sid = 0
 			nearby_pc.begin_dialog(attachee,330)
+			game.new_sid = 0
 			return SKIP_DEFAULT
 	return RUN_DEFAULT
 


### PR DESCRIPTION
This moves the `new_sid = 0` in `san_start_combat` to after the call to begin the dialog with the PC. In Temple+, the dialog call has changed to immediately stop combat, which in turn triggers `san_exit_combat` scripts. These run in the middle of the other script now.

In the original game, the dialog call only exits combat later, because a scheduled event starts the dialogue, which exits combat, and this happens _after_ the `san_start_combat` script has completed.

This was causing Zuggtmoy's script to never be set to 0, meaning that she would repeatedly try to bargain with the PCs as long as she was below 20% health. The reason is that running another script clears the _global_ `new_sid` variable back to -1, which means 'no update'. Unless the second script also sets `new_sid`, the object's script will never be updated.

I just moved the `new_sid = 0` in the Zuggtmoy script to after the dialog call, so that it doesn't get cleared.

I don't think this is a _good_ fix, because it relies on tricky, implicit details of what's going on. A better fix would be to use a stack for tracking these 'global' variables, so that they essentially become script-local. However, that requires making sure that using the stack won't break some other implicit logic in another part of the script system. So I've decided to fix the immediate bug instead of that for the time being.