### PR TITLE
Initialize non-core sources to all sources

### DIFF
--- a/Configurator/IniViewModel.cs
+++ b/Configurator/IniViewModel.cs
@@ -715,7 +715,12 @@ namespace TemplePlusConfig
             
             NonCore = TryReadBool("nonCoreMaterials");
 
-            NonCoreSources = ReadStringList("nonCoreSources");
+            if (tpData["nonCoreSources"] == null) {
+              string[] defaults = {"co8", "spellcompendium", "homebrew", "phb2"};
+              NonCoreSources = new List<string>(defaults);
+            } else {
+              NonCoreSources = ReadStringList("nonCoreSources");
+            }
             
             NewRaces = TryReadBool("newRaces");
             

--- a/TemplePlus/config/config.h
+++ b/TemplePlus/config/config.h
@@ -165,7 +165,13 @@ struct TemplePlusConfig
 
 	std::string GetPath();
 	void SetPath(const std::string &path);
-	
+
+	TemplePlusConfig() {
+		nonCoreSources.insert(PnPSource::SpellCompendium);
+		nonCoreSources.insert(PnPSource::PHB2);
+		nonCoreSources.insert(PnPSource::Homebrew);
+		nonCoreSources.insert(PnPSource::Co8);
+	}
 };
 
 extern TemplePlusConfig config;

--- a/tpdatasrc/tpgamefiles/rules/spells/1051 - Critical Strike.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/1051 - Critical Strike.txt
@@ -18,3 +18,4 @@ min_Target: 1
 max_Target: 1
 radius_Target: 0
 ai_type: ai_action_defensive
+source: Spell Compendium

--- a/tpdatasrc/tpgamefiles/rules/spells/1074 - Snipers Shot.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/1074 - Snipers Shot.txt
@@ -19,3 +19,4 @@ min_Target: 1
 max_Target: 1
 radius_Target: 0
 ai_type: ai_action_defensive
+source: Spell Compendium

--- a/tpdatasrc/tpgamefiles/rules/spells/1076 - Bonefiddle.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/1076 - Bonefiddle.txt
@@ -19,3 +19,4 @@ min_Target: 1
 max_Target: 1
 radius_Target: 0
 ai_type: ai_action_offensive
+source: Spell Compendium

--- a/tpdatasrc/tpgamefiles/rules/spells/1085 - Fell the Greatest Foe.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/1085 - Fell the Greatest Foe.txt
@@ -19,3 +19,4 @@ min_Target: 1
 max_Target: 1
 radius_Target: 0
 ai_type: ai_action_defensive
+source: Spell Compendium

--- a/tpdatasrc/tpgamefiles/rules/spells/1097 - Find the Gap.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/1097 - Find the Gap.txt
@@ -17,3 +17,4 @@ min_Target: 1
 max_Target: 1
 radius_Target: 0
 ai_type: ai_action_defensive
+source: Spell Compendium

--- a/tpdatasrc/tpgamefiles/rules/spells/1098 - Wraithstrike.txt
+++ b/tpdatasrc/tpgamefiles/rules/spells/1098 - Wraithstrike.txt
@@ -18,3 +18,4 @@ min_Target: 1
 max_Target: 1
 radius_Target: 0
 ai_type: ai_action_defensive
+source: Spell Compendium


### PR DESCRIPTION
This initializes the non-core source settings to all the available sources, and fixes a problem where the configurator wouldn't start up if the setting was missing from the ini (probably a null pointer exception).

Both running ToEE and running the configurator should initialize the setting this way, so it doesn't matter which you run first. I made the default all the sources because that's how it would be before the individual sources were selectable.

I've also added sources to a few spell compendium spells that I hadn't caught in the last PR. I think maybe I was trying to decide what to do because they don't appear _solely_ in the spell compendium. But doing something about that will have to wait for a later day.