### PR TITLE
Apply skirmish damage to weaponlike spells

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/scout.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/scout.py
@@ -236,6 +236,7 @@ def SkirmishDamageBonus(attachee, args, evt_obj):
 scoutSkirmish = PythonModifier("Skirmish", 4) #Distance Moved, Spare, Spare, Spare
 scoutSkirmish.MapToFeat("Skirmish")
 scoutSkirmish.AddHook(ET_OnDealingDamage, EK_NONE, SkirmishDamageBonus, ())
+scoutSkirmish.AddHook(ET_OnDealingDamageWeaponlikeSpell, EK_NONE, SkirmishDamageBonus, ())
 scoutSkirmish.AddHook(ET_OnGetAC, EK_NONE, SkirmishAcBonus, ())
 scoutSkirmish.AddHook(ET_OnBeginRound, EK_NONE, SkirmishReset, ())
 scoutSkirmish.AddHook(ET_OnConditionAdd, EK_NONE, SkirmishAdd, ())


### PR DESCRIPTION
These spells don't seem to dispatch `OnDealingDamage`, they dispatch a separate event. Sneak attack has been updated to listen for this event elsewhere, but skirmish wasn't.