### PR TITLE
Initialize feat arrays directly; get rid of racialFeats

### DIFF
--- a/TemplePlus/feat.cpp
+++ b/TemplePlus/feat.cpp
@@ -156,20 +156,6 @@ LegacyFeatSystem::LegacyFeatSystem()
 	rebase(charEditorClassCode, 0x11E72FC0);	// TODO: move this to the appropriate system
 	rebase(ToEE_WeaponFeatCheck, 0x1007C4F0);
 
-	int _racialFeatsTable[VANILLA_NUM_RACES * 10] = { -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		FEAT_SIMPLE_WEAPON_PROFICIENCY_ELF, -1, 0, 0, 0, 0, 0, 0, 0, 0,
-		-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-
-		-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		-1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		-1, 0, 0, 0, 0, 0, 0, 0, 0, 0 }; // table presupposes 10 items on each row, terminator character -1
-	int _rangerArcheryFeats[4 * 2] = { FEAT_RANGER_RAPID_SHOT, 2, FEAT_RANGER_MANYSHOT, 6, FEAT_IMPROVED_PRECISE_SHOT_RANGER, 11, -1, -1 };
-	int _rangerTwoWeaponFeats[4 * 2] = { FEAT_TWO_WEAPON_FIGHTING_RANGER, 2, FEAT_IMPROVED_TWO_WEAPON_FIGHTING_RANGER, 6, FEAT_GREATER_TWO_WEAPON_FIGHTING_RANGER, 11, - 1, -1 };
-
-	memcpy(racialFeats, _racialFeatsTable, sizeof(racialFeats));
-	memcpy(rangerArcheryFeats, _rangerArcheryFeats, sizeof(rangerArcheryFeats));
-	memcpy(rangerTwoWeaponFeats, _rangerTwoWeaponFeats, sizeof(rangerTwoWeaponFeats));
 	featPropertiesTable[FEAT_GREATER_TWO_WEAPON_FIGHTING] = 0x10;
 	featPreReqTable[FEAT_GREATER_TWO_WEAPON_FIGHTING].featPrereqs[2].featPrereqCode = 266;
 	featPreReqTable[FEAT_GREATER_TWO_WEAPON_FIGHTING].featPrereqs[2].featPrereqCodeArg = 11;

--- a/TemplePlus/feat.h
+++ b/TemplePlus/feat.h
@@ -128,7 +128,6 @@ struct LegacyFeatSystem : temple::AddressTable
 	char featPrereqDescrBuffer[5000];
 	std::unordered_set<feat_enums> metamagicFeats;
 
-	uint32_t racialFeats[ 10 * VANILLA_NUM_RACES ];
 	uint32_t HasFeatCount(objHndl objHnd, feat_enums featEnum);
 	uint32_t HasFeatCountByClass(objHndl objHnd, feat_enums featEnum, Stat classEnum, uint32_t rangerSpecializationFeat, uint32_t newDomain1, uint32_t newDomain2, uint32_t alignmentChoiceNew);
 	uint32_t HasFeatCountByClass(objHndl objHnd, feat_enums featEnum, Stat classEnum, uint32_t rangerSpecializationFeat);
@@ -171,8 +170,18 @@ struct LegacyFeatSystem : temple::AddressTable
 	bool IsNonCore(feat_enums feat);
 	void DoForAllFeats(void (__cdecl*cb)(int featEnum));
 	
-	uint32_t rangerArcheryFeats[4 * 2 + 100];
-	uint32_t rangerTwoWeaponFeats[4 * 2 + 100];
+	uint32_t rangerArcheryFeats[4 * 2 + 100] =
+		{ FEAT_RANGER_RAPID_SHOT, 2,
+			FEAT_RANGER_MANYSHOT, 6,
+			FEAT_IMPROVED_PRECISE_SHOT_RANGER, 11,
+			static_cast<uint32_t>(-1), static_cast<uint32_t>(-1)
+		};
+	uint32_t rangerTwoWeaponFeats[4 * 2 + 100] =
+		{ FEAT_TWO_WEAPON_FIGHTING_RANGER, 2,
+			FEAT_IMPROVED_TWO_WEAPON_FIGHTING_RANGER, 6,
+			FEAT_GREATER_TWO_WEAPON_FIGHTING_RANGER, 11,
+			static_cast<uint32_t>(-1), static_cast<uint32_t>(-1)
+		};
 
 
 	void(__cdecl *ToEE_WeaponFeatCheck)();


### PR DESCRIPTION
This is an alternate fix to #873. Instead of just fixing the `memcpy` calls, it moves the array initializations directly to the declarations. Also, it eliminates the `racialFeats` array in `LegacyFeatSystem`, since it seems to be unused.

With this, there are no longer any `memcpy` calls to potentially go out of sync.

I've tested and the Ranger feats still work, so this initialization method seems to behave correctly (even though the initialization is shorter than the full array length).