### PR TITLE
Eliminate uses of `math.floor` in various modifier scripts.

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/brutal_throw.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/brutal_throw.py
@@ -20,10 +20,10 @@ def BrutalThrowAttackBonus(attachee, args, evt_obj):
 		
 	#Add differece between strength and dex bonus
 	strScore = attachee.stat_level_get(stat_strength)
-	strMod = math.floor((strScore - 10)/2)
+	strMod = (strScore - 10)/2
 	
 	dexScore = attachee.stat_level_get(stat_dexterity)
-	dexMod = math.floor((dexScore - 10)/2)
+	dexMod = (dexScore - 10)/2
 	
 	bonus = int(strMod - dexMod) 
 	

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/ki_blast.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/ki_blast.py
@@ -85,7 +85,7 @@ def actionFrame(attachee, args, evt_obj):
     damage_dice = dice_new("1d6")
     damage_dice.number = 3
     wisScore = attachee.stat_level_get(stat_wisdom)
-    damage_dice.bonus = math.floor((wisScore - 10)/2)
+    damage_dice.bonus = (wisScore - 10)/2
     target.spell_damage_weaponlike( attachee, D20DT_FORCE, damage_dice, D20DAP_UNSPECIFIED, 100, D20A_CAST_SPELL, currentSequence.spell_packet.spell_id , return_val, 0) #index of target??
         
     return 0

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/natural_bond.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/natural_bond.py
@@ -1,7 +1,6 @@
 from templeplus.pymod import PythonModifier
 from toee import *
 import tpdp
-import math
 
 # Natural Bond:   Complete Adventurer, p. 111
 
@@ -13,7 +12,7 @@ def QueryNaturalBond(attachee, args, evt_obj):
 	#Add Druid Level to Ranger effective druid level
 	rangerLevel = attachee.stat_level_get(stat_level_ranger) 
 	if rangerLevel >= 4:
-		animalCompanionLevel = math.floor(rangerLevel / 2)
+		animalCompanionLevel = rangerLevel / 2
 	animalCompanionLevel += attachee.stat_level_get(stat_level_druid)
 
 	characterLevel = attachee.stat_level_get(stat_level)

--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/two_weapon_rend.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/two_weapon_rend.py
@@ -66,8 +66,8 @@ def TwoWeaponRendDamageBonus(attachee, args, evt_obj):
 		
 		#Add 1 and a half times the strength score as the bonus
 		strScore = attachee.stat_level_get(stat_strength)
-		strMod = math.floor((strScore - 10)/2)
-		damage_dice.bonus = strMod + math.floor(strMod/2)
+		strMod = (strScore - 10)/2
+		damage_dice.bonus = strMod + strMod/2
 		evt_obj.damage_packet.add_dice(damage_dice, -1, 127)
 		attachee.float_text_line("Rend!")
 	return 0


### PR DESCRIPTION
`math.floor` was being called on the calculated animal companion level. All this actually seems to do is convert the number to a float, because the original calculation is `ranger_level/2`, which is integer division, and automatically truncates.

Later, this value is used with `+=` on an integer-backed field from C++, which crashes with a type error (only int supported). This was causing strange errors in seemingly unrelated situations for reasons I don't completely understand.

This fixes the problem in #887. The crash seems to have been happening in the middle of the level up procedure calculating spells, resulting in no available wizard spells, and no 4th level cleric spells. I don't really understand why the Natural Bond script was being run in the middle of a _different_ character's level up, but apparently it was.