### PR TITLE
Rework spell casting animgoal

### DIFF
--- a/Infrastructure/include/infrastructure/meshes.h
+++ b/Infrastructure/include/infrastructure/meshes.h
@@ -272,7 +272,7 @@ namespace gfx {
 
 		SpellAnimType GetSpellAnimType() const {
 
-			return (SpellAnimType)( (mId & 0xFFFFFFF) + 64 );
+			return (SpellAnimType)( (mId & 0xFFFFFFF) + 65 );
 		}
 
 		bool IsWeaponAnim() const {

--- a/TemplePlus/animgoals/anim_slot.h
+++ b/TemplePlus/animgoals/anim_slot.h
@@ -33,10 +33,12 @@ enum AnimSlotFlag {
 	ASF_STOP_PROCESSING = 2, // Used in context with "killing the animation slot"
 	ASF_UNK3 = 4, // Seen in goalstatefunc_82, goalstatefunc_83, set with 0x8 in
 	// goalstatefunc_42
+	ASF_ACTION = 4,
 	ASF_UNK4 = 8, // Seen in goalstatefunc_82, goalstatefunc_83, set with 0x8 in
 	// goalstatefunc_42
 	ASF_UNK5 = 0x10, // Seen in goalstatefunc_84_animated_forever, set in
 	// goalstatefunc_87
+	ASF_ANIMATING = 0x10,
 	ASF_UNK7 = 0x20, // Seen as 0x30 is cleared in goalstatefunc_7 and goalstatefunc_8
 	ASF_RUNNING = 0x40,
 	ASF_SPEED_RECALC = 0x80,

--- a/TemplePlus/animgoals/animgoals_callbacks.h
+++ b/TemplePlus/animgoals/animgoals_callbacks.h
@@ -150,3 +150,11 @@ int GoalMoveNearUpdateRadiusToReach(AnimSlot &slot); // Originally @ 0x1001bf70
 int GoalAttackEndTurnIfUnreachable(AnimSlot &slot); // Originally @ 0x1001c100
 int AlwaysSucceed(AnimSlot &slot); // Originally @ 0x101f5850
 int AlwaysFail(AnimSlot &slot); // Originally @ 0x10262530
+
+int GoalTestAction(AnimSlot &slot);
+int GoalTestCompletedOnce(AnimSlot &slot);
+int GoalTestAnimating(AnimSlot &slot);
+int GoalUnsetAction(AnimSlot &slot);
+int GoalSpellAnimCompleted(AnimSlot &slot);
+int GoalBeginSpellAnim(AnimSlot &slot);
+int GoalTestAnimatingCasting(AnimSlot &slot);


### PR DESCRIPTION
This PR rewrites the state machine for the `ag_attempt_spell_w_cast_anim` animgoal. This is responsible for the actual spell casting portion of the animation, although I don't think it's called directly, but indirectly via other goals.

The new state machine is based on a lot of fiddling trying to figure out how everything fits together, and the comments try to explain how it works. The differences from the old machine are roughly as follows:

- The old machine had a lot of intermediate states that were just 'go to next state'. The new one doesn't.
- The old machine had unreachable states that I've just removed. I assume these and the last item are just artifacts of the devs changing their approach to things and just disabling various states instead of completely removing them.
- The new machine always plays the 'conjuring' animation one time through at least. This is some cool arm waving that you never get to see in the base game (as far as I can tell).
- The new machine responds much better to interruption by readied actions.
    - The animations themselves have 'action' points within them, and when interrupted, the conjuration was completely restarted at the action point. I _think_ the action point for those is the point at which it's appropriate to switch to the final casting animation, so it would result in characters twitching weirdly when interrupted.
    - The old machine would also call the 'trigger spell' callback every time the animation restarts, which plays the 'begin spell cast' sound, resulting in issue #879. The new machine only ever calls this once. This might also fix game logic embedded in that callback that really shouldn't be called repeatedly (unsure).

There's some other miscellaneous stuff here, too. I added some plausible names to the ASF enum, and `GetSpellAnimType` appears to have been off by one.

I've tested the new animation in controlled circumstances, but haven't played through the game extensively with it. It could use some thorough play testing when it gets included, because it's possible for certain animations to behave poorly. For instance, the `ConjurationConjuring` animation seems like it might be broken; the character just freezes in place while their arms glow, and the animation never actually has an end point. I included a work-around for this in the state machine (it skips the 'play the conjuring through at least once part'), but animations are not universal, so there could be other infinite animations that behave poorly. I could probably adjust things if more are found.