### PR TITLE
Adjust metamagic spell targeting changes

### DIFF
--- a/TemplePlus/action_sequence.cpp
+++ b/TemplePlus/action_sequence.cpp
@@ -489,11 +489,28 @@ void ActionSequenceSystem::ActSeqGetPicker(){
 		dispatch.DispatchMetaMagicModify(d20Sys.globD20Action->d20APerformer, metaMagicData, spellLevel, spellEnum, spellClass);
 
 		auto curSeq = *actSeqSys.actSeqCur;
-		curSeq->spellPktBody.spellRange *= metaMagicData.metaMagicEnlargeSpellCount + 1;
-		SpellEntry spellEntry;
-		if (spellSys.spellRegistryCopy(spellEnum, &spellEntry)){
-			spellEntry.radiusTarget *= metaMagicData.metaMagicWidenSpellCount + 1;
+		auto wideFactor = metaMagicData.metaMagicWidenSpellCount + 1;
+		auto enlargeFactor = metaMagicData.metaMagicEnlargeSpellCount + 1;
+		SpellEntry spellEntry(spellEnum);
+
+		switch (spellEntry.spellRangeType)
+		{
+		case SRT_Specified:
+			// Specified is used for cones and lines, which widen applies to. For
+			// some reason cones don't use radius to determine the cone length.
+			spellEntry.spellRange *= wideFactor;
+			break;
+
+		case SRT_Close:
+		case SRT_Medium:
+		case SRT_Long:
+			// enlarge spell only applies to these range types
+			curSeq->spellPktBody.spellRange *= enlargeFactor;
+		default:
+			spellEntry.radiusTarget *= wideFactor;
+			break;
 		}
+
 		PickerArgs pickArgs;
 		spellSys.pickerArgsFromSpellEntry(&spellEntry, &pickArgs, curSeq->spellPktBody.caster, curSeq->spellPktBody.casterLevel);
 		pickArgs.spellEnum = spellEnum;


### PR DESCRIPTION
This PR changes the way some metamagics apply to spell targeting/AoE.

- Enlarge Spell is only applied to close/medium/long range spells. This is how it's supposed to operate according to the SRD. I suspect there are no spells for which this actually makes a difference, but it's an extra level of correctness in the logic.
- When the range type is `SRT_Specified`, it applies the Widen Spell bonus to the spell's range rather than radius. `SRT_Specified` is used for line and cone spells, and those don't actually use radius for their length, but a value stored for the range. I think this just makes widen properly apply to cone spells (previously it did nothing). For lines, it means widen makes them longer, but not wider (previously these were reversed).

I didn't guard any of this behind strict rules. Technically for lines it's not a strict upgrade like it is for cones, but there's only like two line spells, so I'm not sure it's worth the extra logic to preserve the old behavior.

Also note that this _only_ affects the targeting. As usual with widen, the particles won't match unless you write and use a specific, different particle system for the wide spell.