### PR TITLE
Use a python dispatch to calculate bonus skill points

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/tpModifiers/human.py
+++ b/tpdatasrc/tpgamefiles/scr/tpModifiers/human.py
@@ -20,6 +20,12 @@ def OnGetFavoredClass(attachee, args, evt_obj):
 		evt_obj.return_val = 1
 	return 0
 
+def Bonus1(critter, args, evt_obj):
+	evt_obj.return_val += 1
+
+	return 0
+
 raceSpecObj = PythonModifier(GetConditionName(), 0)
 race_utils.AddBaseMoveSpeed(raceSpecObj, 30)
 raceSpecObj.AddHook(ET_OnD20Query, EK_Q_FavoredClass, OnGetFavoredClass, ())
+raceSpecObj.AddHook(ET_OnD20PythonQuery, "Bonus Skillpoints", Bonus1, ())


### PR DESCRIPTION
This tweaks the way skill points are calculated for each level to allow for conditions to provide bonuses.

- I've factored out the `GetNumSkillPointsPerLevel` replacement into its own function, and made it run a python query with key `"Bonus Skillpoints"` to calculate extra skillpoints, instead of checking for `race_human`
- I made the character creation hook call the above function to calculate the base number of skill points (which gets multiplied by 4). It does a tweak, because this hook doesn't replace the part that adds 4 for humans (so the hook returns 1 fewer for humans).
- I added a hook to the `"Human"` python condition that responds appropriately to the `"Bonus Skillpoints"` query, adding 1 to the result value.