### PR TITLE
Fix get_obj_from_args/set_args_from_obj for D20Signal

### DIFF
--- a/TemplePlus/python/python_dispatcher.cpp
+++ b/TemplePlus/python/python_dispatcher.cpp
@@ -1043,14 +1043,14 @@ PYBIND11_EMBEDDED_MODULE(tpdp, m) {
 		.def_readwrite("return_val", &DispIoD20Signal::return_val)
 		.def_readwrite("data1", &DispIoD20Signal::data1)
 		.def_readwrite("data2", &DispIoD20Signal::data2)
-		.def("get_obj_from_args", [](DispIoD20Query& evtObj)->objHndl {
+		.def("get_obj_from_args", [](DispIoD20Signal& evtObj)->objHndl {
 			
 			auto handle = objHndl::FromUpperAndLower(evtObj.data2, evtObj.data1);
 			if (!gameSystems->GetObj().IsValidHandle(handle))
 				handle = objHndl::null;
 			return handle;
 			}, "Used for python signals that have a handle as the parameter.")
-		.def("set_args_from_obj", [](DispIoD20Query& evtObj, objHndl & handle)->void {
+		.def("set_args_from_obj", [](DispIoD20Signal& evtObj, objHndl & handle)->void {
 
 				if (objSystem->IsValidHandle(handle)) {
 					evtObj.data1 = handle.GetHandleLower();


### PR DESCRIPTION
They seem to have been copied from the D20Query version, without changing the expected event object type.