### PR TITLE
Improve logic for using secondary weapon anim

### DIFF
--- a/TemplePlus/critter.cpp
+++ b/TemplePlus/critter.cpp
@@ -2379,7 +2379,7 @@ objHndl LegacyCritterSystem::GetPrimaryWield(objHndl critter)
 	auto weapr = GetRightWield(critter);
 	auto weapl = GetLeftWield(critter);
 
-	if (weapl && d20Sys.d20Query(critter, DK_QUE_Left_Is_Primary))
+	if (LeftHandIsPrimary(critter))
 		return weapl;
 	else
 		return weapr;
@@ -2390,7 +2390,7 @@ objHndl LegacyCritterSystem::GetSecondaryWield(objHndl critter)
 	auto weapr = GetRightWield(critter);
 	auto weapl = GetLeftWield(critter);
 
-	if (weapl && d20Sys.d20Query(critter, DK_QUE_Left_Is_Primary))
+	if (LeftHandIsPrimary(critter))
 		return weapr;
 	else
 		return weapl;
@@ -2471,6 +2471,19 @@ bool LegacyCritterSystem::OffhandIsLight(objHndl critter)
 	// Otherwise, we're wielding a double weapon, or the offhand is
 	// null, either of which count as light.
 	return true;
+}
+
+// Checks that the left hand is actually the primary weapon. This includes
+// checking that there is an actual weapon equipped (single, shield or
+// double), because fighting with an empty off hand is currently not actually
+// supported.
+bool LegacyCritterSystem::LeftHandIsPrimary(objHndl critter)
+{
+	if (!critter || !objSystem->IsValidHandle(critter))
+		return false;
+
+	auto weapl = GetLeftWield(critter);
+	return weapl && d20Sys.d20Query(critter, DK_QUE_Left_Is_Primary);
 }
 
 int LegacyCritterSystem::SkillBaseGet(objHndl handle, SkillEnum skill){

--- a/TemplePlus/critter.h
+++ b/TemplePlus/critter.h
@@ -446,6 +446,7 @@ struct LegacyCritterSystem : temple::AddressTable
 	bool CanTwoWeaponFight(objHndl hndl);
 	FightingStyle GetFightingStyle(objHndl hndl);
 	bool OffhandIsLight(objHndl hndl);
+	bool LeftHandIsPrimary(objHndl critter);
 #pragma endregion
 
 #pragma region Spellcasting

--- a/TemplePlus/d20.cpp
+++ b/TemplePlus/d20.cpp
@@ -1319,7 +1319,7 @@ ActionErrorCode D20ActionCallbacks::PerformStandardAttack(D20Actn* d20a)
 		hitAnimIdx = (d20a->data1 - (ATTACK_CODE_NATURAL_ATTACK + 1)) % 3;
 	}
 
-	if (d20Sys.d20Query(d20a->d20APerformer, DK_QUE_Left_Is_Primary))
+	if (critterSys.LeftHandIsPrimary(d20a->d20APerformer))
 		useSecondaryAnim = !useSecondaryAnim;
 
 	combatSys.ToHitProcessing(*d20a);


### PR DESCRIPTION
This factors out a check for considering the left hand as the primary weapon, and uses it in the spot that determines the weapon animation to use.

I noticed that if you had designated the left hand as the primary, but unequipped the left hand weapon, the animation logic was still using the swapping just from checking the toggle. The actual attack logic doesn't do this. So, you would appear to punch when using a light weapon, or sometimes use alternate animations for two handed weapons.