### PR TITLE
Import tweaked version of Color Spray script

### DIFF
--- a/tpdatasrc/tpgamefiles/scr/Spell066 - Color Spray.py
+++ b/tpdatasrc/tpgamefiles/scr/Spell066 - Color Spray.py
@@ -1,0 +1,54 @@
+from toee import *
+from tptrace import trace
+
+def OnBeginSpellCast(spell):
+	trace("Color Spray OnBeginSpellCast")
+	trace("spell.target_list=", spell.target_list)
+	trace("spell.caster=", spell.caster, " caster.level=", spell.caster_level)
+
+def OnSpellEffect( spell ):
+	trace("Color Spray OnSpellEffect")
+
+	remove_list = []
+
+	spell.duration = 0
+
+	dc = spell.dc
+	caster = spell.caster
+
+	game.particles('sp-Color Spray', caster)
+
+	for target_item in spell.target_list:
+		target = target_item.obj
+		if target.d20_query(Q_Critter_Is_Blinded):
+			game.particles('Fizzle', target)
+			remove_list.append(target)
+			continue
+
+		if target.saving_throw_spell(dc, D20_Save_Will, D20STD_F_NONE, caster, spell.id):
+			# saving throw successful
+			target.float_mesfile_line('mes\\spell.mes', 30001)
+			game.particles('Fizzle', target)
+			remove_list.append(target)
+			continue
+
+		# saving throw unsuccessful
+		target.float_mesfile_line('mes\\spell.mes', 30002)
+
+		if target.hit_dice_num >= 5:
+			target.condition_add('sp-Color Spray Stun', spell.id)
+
+		elif target.hit_dice_num >= 3:
+			target.condition_add('sp-Color Spray Blind', spell.id)
+
+		else:
+			target.condition_add('sp-Color Spray Unconscious', spell.id)
+
+	spell.target_list.remove_list(remove_list)
+	spell.spell_end(spell.id)
+
+def OnBeginRound(spell):
+	trace("Color Spray OnBeginRound")
+
+def OnEndSpellCast(spell):
+	trace("Color Spray OnEndSpellCast")

--- a/tpdatasrc/tpgamefiles/scr/tptrace.py
+++ b/tpdatasrc/tpgamefiles/scr/tptrace.py
@@ -1,0 +1,42 @@
+# Print functions that hook into the Temple+ config settings for log level.
+#
+# Right now it just checks the configured log level itself and does its own
+# logic of whether or not to print. This means that all messages will show up
+# in the log tagged as the "info" level even if they are not tagged as such
+# here. Perhaps at a later date this could be hooked into the overall Temple+
+# logging system more directly for more precise output.
+
+import tpdp
+
+def log(at_level, stuff):
+	level = tpdp.config_get_int("LogLevel")
+
+	# nothing to print
+	if len(stuff) <= 0: return
+
+	# level 6 is "off", so cap at_level
+	if min(at_level, 5) < level: return
+
+	msg = ""
+	for thing in stuff:
+		msg = "{}{}".format(msg, thing)
+
+	print msg
+
+def trace(*stuff):
+	log(0, stuff)
+
+def debug(*stuff):
+	log(1, stuff)
+
+def info(*stuff):
+	log(2, stuff)
+
+def warn(*stuff):
+	log(3, stuff)
+
+def err(*stuff):
+	log(4, stuff)
+
+def critical(*stuff):
+	log(5, stuff)


### PR DESCRIPTION
This version removes the 1d6 target cap (holdover from 3.0) and changes the print statements to calls to a new, simple logging module for spell (and other) scripts.

The log module checks the Temple+ log level to determine whether to actually print, so most of the spammy messages in spell scripts could eventually be replaced with `trace()` calls to avoid all the noise.

Making other scripts use this logging instead is future work.