### PR TITLE
Fix some logic regarding AoO provoking

### DIFF
--- a/TemplePlus/action_sequence.cpp
+++ b/TemplePlus/action_sequence.cpp
@@ -2226,6 +2226,7 @@ int32_t ActionSequenceSystem::DoAoosByAdjcentEnemies(objHndl obj)
 
 int32_t ActionSequenceSystem::ProvokeAooFrom(objHndl provoker, objHndl enemy)
 {
+	if (!provoker || !enemy) return 0;
 	if (objects.GetFlags(enemy) & OF_INVULNERABLE) // see above
 		return 0;
 

--- a/TemplePlus/d20.cpp
+++ b/TemplePlus/d20.cpp
@@ -1183,6 +1183,15 @@ int32_t LegacyD20System::D20ActionTriggersAoO(D20Actn* d20a, TurnBasedStatus* tb
 			return 2;
 	}
 
+	bool isStdAtk = d20a->d20ActType == D20A_STANDARD_ATTACK;
+	isStdAtk = isStdAtk || d20a->d20ActType == D20A_UNSPECIFIED_ATTACK;
+	isStdAtk = isStdAtk || d20a->d20ActType == D20A_CHARGE;
+
+	// If the action is not a standard melee attack, the checks below for being
+	// armed are irrelevant. The action is the 'provoke from all surrounding'
+	// variety. TODO: switch to a flag for type result=2 actions?
+	if (!isStdAtk) return 1;
+
 	if (d20a->d20Caf & D20CAF_TOUCH_ATTACK
 		|| d20Sys.GetAttackWeapon(d20a->d20APerformer, d20a->data1, (D20CAF)d20a->d20Caf) 
 		|| dispatch.DispatchD20ActionCheck(d20a, tbStat, dispTypeGetCritterNaturalAttacksNum))


### PR DESCRIPTION
In the function that provokes an AoO from a specific target, guard against null arguments to avoid trying to access fields of null objects.

In the check for whether a D20 action provokes an AoO, many action types were defaulting to the 'is the performer armed' check, even though they aren't weapon attacks.

Fixes the crash from #900