### PR TITLE
Divide XP before putting it in the ego pile

### DIFF
--- a/TemplePlus/xp.cpp
+++ b/TemplePlus/xp.cpp
@@ -252,8 +252,8 @@ void XPTableForHighLevels::GiveXPAwards(){
 			}
 			
 		}
-		xpForxpPile += xpGainRaw;
 		xpGainRaw = int((float)(xpGainRaw) / fNumLivingPartyMembers);
+		xpForxpPile += xpGainRaw;
 		//if (templeFuncs.ObjXPGainProcess(objHnd, xpGainRaw)) {
 		if (xpawarddd->XpGainProcess(objHnd, xpGainRaw)){
 			auto obj = objSystem->GetObject(objHnd);


### PR DESCRIPTION
The logbook tracks the most XP gained in a single fight. The calculation for this was adding the _full_ XP for each opponent for each character, rather than just that character's share. This ends up multiplying the recorded XP by the number of (surviving) party members, rather than recording the actual XP gained.

It looks like this was a vanilla bug that got ported to the T+ replacement.