### PR TITLE
Alter `has_metamagic_feat` to account for class feats

### DIFF
--- a/TemplePlus/ui/ui_char_editor.cpp
+++ b/TemplePlus/ui/ui_char_editor.cpp
@@ -554,13 +554,8 @@ PYBIND11_EMBEDDED_MODULE(char_editor, mm) {
 		auto handle = chargen.GetEditedChar();
 		auto &charPkt = chargen.GetCharEditorSelPacket();
 
-		auto featList = feats.GetFeats(handle);
-
-		bool hasMMFeat = false;
-		for (auto feat : featList) {
-			if (feats.IsMetamagicFeat(feat)) {
-				featCount++;
-			}
+		for (auto mmfeat : feats.metamagicFeats) {
+			featCount += feats.HasFeatCountByClass(handle, mmfeat);
 		}
 
 		if (feats.IsMetamagicFeat(charPkt.feat0)) {


### PR DESCRIPTION
Previously, `has_metamagic_feat` was using `GetFeats` to look for existing feats on the character. However, that only returns the feats that have been explicitly selected by the character, not feats you get automatically from class levels.

I changed the logic to loop over all metamagic feats and call `HasFeatCountByClass` instead.

Fixes #913 