### PR TITLE
Optionally highlight containers when tab is pressed

### DIFF
--- a/Configurator/HouseRulesWindow.xaml
+++ b/Configurator/HouseRulesWindow.xaml
@@ -25,6 +25,7 @@
                         <CheckBox VerticalAlignment="Center" Content="Fast Sneak Animation" IsChecked="{Binding FastSneaking}" Margin="0,5,0,5" ToolTip="Makes sneak animations as fast as your normal movement."/>
                         <CheckBox VerticalAlignment="Center" Content="Disable Door Re-Locking" IsChecked="{Binding DisableDoorRelocking}" Margin="0,5,0,5" ToolTip="Doors that were unlocked via the Open Lock skill will no longer become re-locked when you come back again."/>
                         <CheckBox VerticalAlignment="Center" Content="Disable Screen Shakes" IsChecked="{Binding DisableScreenShakes}" Margin="0,5,10,5" ToolTip="Disables the screen shake effect from animations. For example from the Hill Giant movement - useful when using Hill Giant PCs."/>
+                        <CheckBox VerticalAlignment="Center" Content="HighlightContainers" IsChecked="{Binding HighlightContainers}" Margin="0,5,10,5" ToolTip="Include containers in highlighting when tab is pressed."/>
 
                     </StackPanel>
                     <GridSplitter x:Name="GridSplitter_Gen" HorizontalAlignment="Left" Height="360" Margin="241,10,0,0" VerticalAlignment="Top" Width="3"/>

--- a/Configurator/IniViewModel.cs
+++ b/Configurator/IniViewModel.cs
@@ -144,6 +144,7 @@ namespace TemplePlusConfig
           "WildshapeUsableItems", typeof(bool), typeof(IniViewModel), new PropertyMetadata(default(bool)));
         public static readonly DependencyProperty DisableReachWeaponDonutProperty = DependencyProperty.Register(
           "DisableReachWeaponDonut", typeof(bool), typeof(IniViewModel), new PropertyMetadata(default(bool)));
+        public static readonly DependencyProperty HighlightContainersProperty = DependencyProperty.Register("HighlightContainers", typeof(bool), typeof(IniViewModel), new PropertyMetadata(default(bool)));
 
         public static readonly DependencyProperty DumpFullMemoryProperty = DependencyProperty.Register(
           "DumpFullMemory", typeof(bool), typeof(IniViewModel), new PropertyMetadata(default(bool)));
@@ -467,6 +468,12 @@ namespace TemplePlusConfig
             set { SetValue(DisableReachWeaponDonutProperty, value); }
         }
 
+        public bool HighlightContainers
+        {
+            get { return (bool)GetValue(HighlightContainersProperty); }
+            set { SetValue(HighlightContainersProperty, value); }
+        }
+
         public bool DumpFullMemory
         {
             get { return (bool)GetValue(DumpFullMemoryProperty); }
@@ -746,6 +753,7 @@ namespace TemplePlusConfig
 
             DisableReachWeaponDonut = TryReadBool("disableReachWeaponDonut");
 
+            HighlightContainers = TryReadBool("highlightContainers");
         }
 
     public void SaveToIni(IniData iniData)
@@ -820,6 +828,7 @@ namespace TemplePlusConfig
             tpData["showTargetingCirclesInFogOfWar"] = ShowTargetingCirclesInFogOfWar ? "true" : "false";
             tpData["wildShapeUsableItems"] = WildshapeUsableItems ? "true" : "false";
             tpData["disableReachWeaponDonut"] = DisableReachWeaponDonut ? "true" : "false";
+            tpData["highlightContainers"] = HighlightContainers ? "true" : "false";
 
 
             tpData["pointBuyPoints"] = PointBuyPoints.ToString();

--- a/TemplePlus/config/config.cpp
+++ b/TemplePlus/config/config.cpp
@@ -264,6 +264,7 @@ static ConfigSetting configSettings[] = {
 	CONF_BOOL(stricterRulesEnforcement),
 	CONF_BOOL(preferPoisonSpecFile),
 	CONF_BOOL(disableReachWeaponDonut),
+	CONF_BOOL(highlightContainers),
 	CONF_BOOL(disableAlignmentRestrictions),
 	CONF_BOOL(disableCraftingSpellReqs),
 	CONF_BOOL(disableMulticlassXpPenalty),

--- a/TemplePlus/config/config.h
+++ b/TemplePlus/config/config.h
@@ -127,6 +127,7 @@ struct TemplePlusConfig
 	bool disableDoorRelocking = false;
 	bool dialogueUseBestSkillLevel = false; // uses best skill level from the (PC) group in dialogue checks
 	bool disableReachWeaponDonut = false; // set to true to restore vanilla ToEE reach weapon behavior
+	bool highlightContainers = false; // highlight containers when tab is pressed
 
 	bool newClasses = false; // Prestige classes and such
 	bool newRaces = false; // Drow etc.

--- a/TemplePlus/gamesystems/mapobjrender.cpp
+++ b/TemplePlus/gamesystems/mapobjrender.cpp
@@ -262,7 +262,8 @@ void MapObjectRenderer::RenderObject(objHndl handle, bool showInvisible) {
 	if (mShowHighlights
 		&& (objects.IsEquipmentType(type) && !(flags & (OF_INVENTORY | OF_CLICK_THROUGH))
 			|| critterSys.IsLootableCorpse(handle)
-			|| type == obj_t_portal))
+			|| type == obj_t_portal
+			|| (config.highlightContainers && type == obj_t_container)))
 	{
 		RenderObjectHighlight(handle, mHighlightMaterial);
 


### PR DESCRIPTION
This adds an option for including containers in the object highlighting when tab is pressed. I've heard the steam version does this, although I haven't looked myself to see exactly what it's like.