### PR TITLE
feat: action_possible and target_is_surrounded, #861

### DIFF
--- a/TemplePlus/pathfinding.cpp
+++ b/TemplePlus/pathfinding.cpp
@@ -648,7 +648,11 @@ bool Pathfinding::GetAlternativeTargetLocation(Path* pqr, PathQuery* pq)
 bool Pathfinding::TargetSurrounded(Path* pqr, PathQuery* pq)
 {
 	if (config.disableTargetSurrounded) return false;
+	return TargetSurroundedCheck(pqr, pq);
+}
 
+bool Pathfinding::TargetSurroundedCheck(Path* pqr, PathQuery* pq)
+{
 	if (    (pq->flags & PQF_IGNORE_CRITTERS) 
 		|| !(pq->flags & PQF_TARGET_OBJ ) 
 		|| !(pq->flags & PQF_HAS_CRITTER)

--- a/TemplePlus/pathfinding.h
+++ b/TemplePlus/pathfinding.h
@@ -220,6 +220,7 @@ struct Pathfinding : temple::AddressTable {
 		Use in combat only.
 	*/
 	bool TargetSurrounded(Path* pqr, PathQuery* pq);
+	bool TargetSurroundedCheck(Path* pqr, PathQuery* pq);
 
 	int FindPath(PathQuery* pq, PathQueryResult* result);
 	


### PR DESCRIPTION
Introduces PyObjHandle_ActionPossible and PyObjHandle_TargetIsSurrounded functions to the Python API, allowing scripts to check if an action is possible and if a target is surrounded. Refactors pathfinding to extract TargetSurroundedCheck for reuse.