### PR TITLE
Add a vsync option

### DIFF
--- a/Configurator/IniViewModel.cs
+++ b/Configurator/IniViewModel.cs
@@ -31,6 +31,9 @@ namespace TemplePlusConfig
         public static readonly DependencyProperty AntiAliasingProperty = DependencyProperty.Register(
             "AntiAliasing", typeof(bool), typeof(IniViewModel), new PropertyMetadata(default(bool)));
 
+        public static readonly DependencyProperty VSyncProperty = DependencyProperty.Register(
+            "VSync", typeof(bool), typeof(IniViewModel), new PropertyMetadata(default(bool)));
+
         public static readonly DependencyProperty SoftShadowsProperty = DependencyProperty.Register(
             "SoftShadows", typeof (bool), typeof (IniViewModel), new PropertyMetadata(default(bool)));
 
@@ -233,6 +236,12 @@ namespace TemplePlusConfig
         {
             get { return (bool)GetValue(AntiAliasingProperty); }
             set { SetValue(AntiAliasingProperty, value); }
+        }
+
+        public bool VSync
+        {
+            get { return (bool)GetValue(VSyncProperty); }
+            set { SetValue(VSyncProperty, value); }
         }
 
         public bool SoftShadows
@@ -624,6 +633,7 @@ namespace TemplePlusConfig
 
             SoftShadows = tpData["softShadows"] == "true";
             AntiAliasing = tpData["antialiasing"] == "true";
+            VSync = tpData["vsync"] == "true";
             WindowedMode = tpData["windowed"] == "true";
             WindowedLockCursor = tpData["windowedLockCursor"] == "true";
             DungeonMaster = tpData["dungeonMaster"] == "true";
@@ -838,6 +848,7 @@ namespace TemplePlusConfig
             tpData["windowWidth"] = RenderWidth.ToString();
             tpData["windowHeight"] = RenderHeight.ToString();
             tpData["antialiasing"] = AntiAliasing? "true" : "false";
+            tpData["vsync"] = VSync ? "true" : "false";
             tpData["softShadows"] = SoftShadows ? "true" : "false";
             tpData["windowedLockCursor"] = WindowedLockCursor ? "true" : "false";
             tpData["dungeonMaster"] = DungeonMaster ? "true" : "false";

--- a/Configurator/MainWindow.xaml
+++ b/Configurator/MainWindow.xaml
@@ -34,6 +34,7 @@
                 <CheckBox VerticalAlignment="Center" Content="Run in Windowed Mode" IsChecked="{Binding WindowedMode}" Margin="0,5,0,5" />
                 <CheckBox VerticalAlignment="Center" Content="Disable Automatic Updates" IsChecked="{Binding DisableAutomaticUpdates}" Margin="0,5,0,5" />
                 <CheckBox VerticalAlignment="Center" Content="Anti Aliasing" IsChecked="{Binding AntiAliasing}" Margin="0,5,0,5" ToolTip="You may have to disable this if you have an integrated GPU." />
+                <CheckBox VerticalAlignment="Center" Content="VSync" IsChecked="{Binding VSync}" Margin="0,5,0,5" /> 
                 <CheckBox VerticalAlignment="Center" Content="Enable Soft Shadows (GPU intensive)" IsChecked="{Binding SoftShadows}" Margin="0,5,0,5" />
                 <CheckBox VerticalAlignment="Center" Content="Lock Cursor to Window" IsChecked="{Binding WindowedLockCursor}" Margin="0,5,0,5" ToolTip="Locks the cursor to the window area when using windowed mode and the window is active."/>
                 <CheckBox VerticalAlignment="Center" Content="Dungeon Master" IsChecked="{Binding DungeonMaster}" Margin="0,5,0,5" ToolTip="Enables the Dungeon Master UI, which allows you to spawn creatures and edit existing ones."/>

--- a/Infrastructure/include/graphics/device.h
+++ b/Infrastructure/include/graphics/device.h
@@ -316,6 +316,7 @@ namespace gfx {
 		void SetCurrentCamera(WorldCameraPtr camera);
 
 		void SetAntiAliasing(bool enable, uint32_t samples, uint32_t quality);
+		void SetVSync(bool enable);
 		
 		template<typename T>
 		void UpdateBuffer(VertexBuffer &buffer, gsl::span<T> data) {

--- a/Infrastructure/src/graphics/device.cpp
+++ b/Infrastructure/src/graphics/device.cpp
@@ -1,4 +1,3 @@
-
 #include "graphics/device.h"
 #include "graphics/bufferbinding.h"
 #include "graphics/dynamictexture.h"
@@ -77,6 +76,7 @@ struct RenderingDevice::Impl {
 
 	// Anti Aliasing Settings
 	bool antiAliasing = false;
+	bool vsync = true;
 	uint32_t msaaSamples = 4;
 	uint32_t msaaQuality = 0;
 
@@ -273,6 +273,10 @@ void RenderingDevice::SetAntiAliasing(bool enable, uint32_t samples, uint32_t qu
 		mD3d11Device->CreateRasterizerState(&gpuDesc, &entry.second->mGpuState);
 	}
   }
+}
+
+void RenderingDevice::SetVSync(bool enable) {
+  mImpl->vsync = enable;
 }
 
 void RenderingDevice::UpdateResource(ID3D11Resource *resource, const void *data,
@@ -545,7 +549,7 @@ void RenderingDevice::PresentForce() {
   return false;
   }*/
 
-  D3DLOG(mSwapChain->Present(0, 0));
+  D3DLOG(mSwapChain->Present(mImpl->vsync, 0));
 }
 
 void RenderingDevice::Flush()

--- a/TemplePlus/config/config.cpp
+++ b/TemplePlus/config/config.cpp
@@ -209,6 +209,7 @@ static ConfigSetting configSettings[] = {
 	//CONF_BOOL(editor),
 	CONF_BOOL(windowed),
 	CONF_BOOL(antialiasing),
+	CONF_BOOL(vsync),
 	CONF_BOOL(softShadows),
 	CONF_BOOL(noSound),
 	CONF_BOOL(featPrereqWarnings),

--- a/TemplePlus/config/config.h
+++ b/TemplePlus/config/config.h
@@ -48,6 +48,7 @@ struct TemplePlusConfig
 	bool noRandomEncounters = false; // Previously -norandom
 	bool noMsMouseZ = false; // Previously -nomsmousez
 	bool antialiasing = true; // Previously -noantialiasing
+	bool vsync = true;
 	uint32_t displayAdapter = 0; // Which adapter to use. 0 = default
 	uint8_t msaaSamples = 4; // If antialiasing is true
 	uint8_t msaaQuality = 0; // For vendor specific AA

--- a/TemplePlus/tig/tig_startup.cpp
+++ b/TemplePlus/tig/tig_startup.cpp
@@ -107,6 +107,7 @@ TigInitializer::TigInitializer(HINSTANCE hInstance)
 	mRenderingDevice->SetAntiAliasing(config.antialiasing,
 		config.msaaSamples,
 		config.msaaQuality);
+	mRenderingDevice->SetVSync(config.vsync);
 
 	mDebugUI = std::make_unique<DebugUI>(*mRenderingDevice);
 	// Install a message filter for the debug UI


### PR DESCRIPTION
This adds an option that tells DirectX to do vsync during the `Present` call. This lowers CPU usage (and in my case, stops T+ from causing coil whine from my computer).

I made it an option in case some people don't want it, or it causes unforeseen problems.

Fixes #837 the right way (I think you don't want to be doing `Sleep` calls in a game loop, because the actual amount of sleep time is unreliable).